### PR TITLE
Point reader to Railway API

### DIFF
--- a/src/pages/chapter/[hash].jsx
+++ b/src/pages/chapter/[hash].jsx
@@ -3,6 +3,10 @@ import { useEffect, useRef, useState } from "react";
 import ImageCanvas from "../../components/ImageCanvas";
 import Head from "next/head";
 
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL ??
+  "https://manga-panel-extractor-production.up.railway.app";
+
 export default function Page() {
   const router = useRouter();
   const [data, setData] = useState(null);
@@ -11,8 +15,7 @@ export default function Page() {
   useEffect(() => {
     if (!router.isReady) return;
 
-    const url = `https://api2.onepanel.app/v2/chapter/${router.query.hash}`;
-    // const url = `http://localhost:8000/v2/chapter/${router.query.hash}`;
+    const url = `${API_URL}/v2/chapter/${router.query.hash}`;
 
     fetch(url, {
       mode: "cors",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,10 @@ import Header from "../components/Header";
 import Footer from "../components/Footer";
 import { useRouter } from "next/router";
 
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL ??
+  "https://manga-panel-extractor-production.up.railway.app";
+
 const Home: NextPage = () => {
   const [data, setData] = useState(null);
   const [isLoading, setLoading] = useState(false);
@@ -31,9 +35,7 @@ const Home: NextPage = () => {
     }
     setLoading(true);
 
-    // const url = `${process.env.SERVER_URL}:${process.env.SERVER_PORT}/chapter`
-    const url = `https://api2.onepanel.app/v2/chapter`;
-    // const url = `http://localhost:8000/v2/chapter`;
+    const url = `${API_URL}/v2/chapter`;
 
     fetch(url, {
       mode: "cors",


### PR DESCRIPTION
Configures the frontend to use NEXT_PUBLIC_API_URL with the deployed Railway FastAPI service as the fallback. Verified with a production build.