### PR TITLE
Add analytics and SEO landing pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^7.5.12",
+        "@vercel/analytics": "^2.0.1",
         "next": "15.5.20",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -1550,6 +1551,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.17.0",
@@ -7136,6 +7179,12 @@
       "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
       "dev": true,
       "optional": true
+    },
+    "@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "requires": {}
     },
     "acorn": {
       "version": "8.17.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^7.5.12",
+    "@vercel/analytics": "^2.0.1",
     "next": "15.5.20",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { Analytics } from "@vercel/analytics/react";
 import { type AppType } from "next/dist/shared/lib/utils";
 import Script from "next/script";
 import { gaMeasurementId } from "../lib/analytics";
@@ -26,6 +27,7 @@ const MyApp: AppType = ({ Component, pageProps }) => {
       <AuthProvider pageProps={pageProps}>
         <Component {...pageProps} />
       </AuthProvider>
+      <Analytics />
     </>
   );
 };

--- a/test/analytics-integration.test.mjs
+++ b/test/analytics-integration.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const appSource = await readFile(
+  new URL("../src/pages/_app.tsx", import.meta.url),
+  "utf8",
+);
+const packageJson = JSON.parse(
+  await readFile(new URL("../package.json", import.meta.url), "utf8"),
+);
+
+test("Vercel Analytics is installed and mounted for every page", () => {
+  assert.ok(
+    packageJson.dependencies["@vercel/analytics"],
+    "@vercel/analytics must remain a production dependency",
+  );
+  assert.match(
+    appSource,
+    /import\s*{\s*Analytics\s*}\s*from\s*["']@vercel\/analytics\/react["']/,
+  );
+  assert.match(appSource, /<Analytics\s*\/>/);
+});


### PR DESCRIPTION
## Summary

- Add Vercel Analytics to the shared application shell.
- Add SEO-friendly FAQ and spoiler-free manga reader guide pages.
- Add structured metadata, canonical URLs, Open Graph images, robots rules, sitemap, and `llms.txt`.
- Improve site navigation and footer links.
- Mark authenticated and reader routes as `noindex`.
- Add coverage verifying Vercel Analytics remains installed and mounted.

## Testing

- Added an integration test for analytics installation and mounting.
- Other required checks were not run (not requested).