### PR TITLE
Add Free and Pro segmentation modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,19 @@ avoiding spoilers from the rest of the page.
 Set `NEXT_PUBLIC_GA_MEASUREMENT_ID` to a GA4 measurement ID, for example
 `G-XXXXXXXXXX`, to load Google Analytics and emit launch funnel events:
 
+- `mode_selected`
 - `chapter_url_submitted`
 - `chapter_created`
+- `upgrade_displayed`
+- `authentication_continuation`
+- `checkout_continuation`
 - `checkout_started`
 - `checkout_redirect_created`
 - `billing_portal_opened`
 - `billing_portal_redirect_created`
 
+Events include only mode, continuation stage, sign-in state, and UI source.
+Chapter URLs, hashes, image paths, and chapter content are never included.
 Subscription completion should be tracked by the API or Stripe webhook, because
 the frontend cannot reliably observe completed checkout after the user leaves
 the site.
@@ -67,33 +73,55 @@ the site.
   without blocking the rest of the chapter.
 - API calls have a two-minute timeout, validate HTTP status and response shape,
   and expose retryable errors to the user.
-- Only HTTPS URLs whose hostname is exactly `opchapters.com` are accepted.
+- Standard chapters can be created and read without an account.
+- GPT-5.6 Layout creation requires OnePanel Pro. Its results can be read by any
+  signed-in account.
+- HTTP(S) chapter URLs from any source are accepted. Bare domains,
+  protocol-relative links, angle-bracket links, and Markdown links are
+  normalized before submission; the API determines whether it can process the
+  source.
 
 ## Configuration and API contract
 
 The browser calls the same-origin `/api/onepanel/*` rewrite, which forwards to
 `NEXT_PUBLIC_API_URL`:
 
-- `POST /v2/chapter` with `{ "chapter_url": "..." }`
+- `POST /v2/chapter` with
+  `{ "chapter_url": "...", "segmentation_mode": "standard" }`
 - `GET /v2/chapter/:hash`
 
 The POST response must contain a non-empty `chapter_hash`. A chapter must contain
 at least one page; every page must contain an image URL and at least one panel
 with a coordinate path.
 
+`segmentation_mode` is either `standard` or `gpt-5.6-layout`; Standard is the
+backward-compatible default. Provider model identifiers are configured only on
+the API and are never accepted from the browser. The API returns stable
+`sign_in_required` and `subscription_required` error codes for access failures.
+
 Because `NEXT_PUBLIC_API_URL` is used by the frontend deployment, it must not
 contain secrets.
 
 ## Authentication and billing
 
-Clerk provides browser authentication. The frontend sends the current Clerk
-session token to the API as a bearer token for every chapter and billing
-request. The API validates that token and enforces an active Stripe subscription
-for chapter creation and retrieval.
+Clerk provides browser authentication. Chapter requests include the current
+Clerk token when one is available; billing requests always require it. The API
+is the authorization boundary: Standard creation and retrieval are public,
+GPT-5.6 Layout creation requires an active Pro subscription, and GPT-5.6 Layout
+retrieval requires any valid signed-in account.
 
 Stripe Checkout sells one €4.99 EUR monthly subscription with no free trial.
 Stripe's Customer Portal handles cancellation and payment-method management.
 The API, not frontend visibility, is the authorization boundary.
+
+When a signed-out or free user selects GPT-5.6 Layout, the browser stores only a
+versioned URL, mode, and continuation stage in `sessionStorage`. The record
+survives authentication and Checkout within that tab, is strictly validated
+before use, and is cleared after successful chapter creation. Returning from
+Checkout restores the composer but never submits automatically.
+
+Deploy the compatible API before this frontend so anonymous Standard requests
+and mode-specific access errors are available when the UI launches.
 
 ## Maintenance
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@clerk/nextjs": "^7.5.12",
         "@vercel/analytics": "^2.0.1",
-        "next": "15.5.20",
+        "next": "15.5.22",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "zod": "^4.4.3"
@@ -739,9 +739,10 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.20.tgz",
-      "integrity": "sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw=="
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.22.tgz",
+      "integrity": "sha512-O5BlKb3KtsHkvO0gjjV66PuJnAgCtIEIzwkt50HRAHsQkU1t77eksIXSZV84/WMtZJjWrnDUPKHVRi0D62nSAA==",
+      "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "15.5.20",
@@ -781,12 +782,13 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.20.tgz",
-      "integrity": "sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.22.tgz",
+      "integrity": "sha512-/VISwtffSg8+fVvBbXdglsvruCsdbBC4dG25iU6xascKVqfQKsj/OtjGnOEkIS7pX5GB9e9/r5QprpicsGL3gw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -796,12 +798,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.20.tgz",
-      "integrity": "sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.22.tgz",
+      "integrity": "sha512-NiA9ve8hbiuhG/Q17a2mZDRVxMTtg3rTOgjLnDaLlE+AEPAQlkkuKrfePEbeOrgYmX0U2KGX4EVEn09hXU5GlQ==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -811,12 +814,16 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.20.tgz",
-      "integrity": "sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.22.tgz",
+      "integrity": "sha512-vAPa9vltW+UW/KWtjXeSUFgV3wb1x9d/BeyC6WFI6eBpL0D2f70oGwtOp6193mNW3qusrpgBzMQferPf+Zh8Dw==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -826,12 +833,16 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.20.tgz",
-      "integrity": "sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.22.tgz",
+      "integrity": "sha512-iknK80pWlNDnkdSr13bd8mMuG3Z2oTxODwsZHvuMY7caMk77+rBLdHVWsy8v2EVa3ZojJ/+wJX5fnq8va6Gv8A==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -841,12 +852,16 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.20.tgz",
-      "integrity": "sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.22.tgz",
+      "integrity": "sha512-penuEdkwU2OOAiS+n4LE8T/VIoCfAI01QcLZTJ2xc3+l4Q22L/DzURocmI2LU1b+8BMQoLAP1Sze3uYAZT05Bg==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -856,12 +871,16 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.20.tgz",
-      "integrity": "sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.22.tgz",
+      "integrity": "sha512-ZM0BKJm3FZ+guG6WT6PcyOLtp6paZ5tngcJC/uUKvLW4Y0TQnnVi1+UGdo8Q6Yxp5gaS82pmC1rD/oFlhkWB3g==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -871,12 +890,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.20.tgz",
-      "integrity": "sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.22.tgz",
+      "integrity": "sha512-rY/YaumrZaS0//94BnHLF5VSRp0GFUO4GvXNuoCBb0cGSci96yO+p1JaNL2aq9YZAYv9cuZRziV02x5IQH/wjg==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -886,12 +906,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.20.tgz",
-      "integrity": "sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.22.tgz",
+      "integrity": "sha512-s5IA4cyrbR2XK/5NWcu5dp8CfPBiKME+UhvNperia7uQybEgg5+LIhGMiY37WQE4rcI4owsDcU4IVUjLoTuDkA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1971,10 +1992,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4309,15 +4331,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4353,11 +4376,12 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.20.tgz",
-      "integrity": "sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.22.tgz",
+      "integrity": "sha512-mrtal1sRxO4YrlDS98sDuIvGZivKbFix8w7oAL9ZynfOgc3cADQOQgvwtMooc18Qr8bKzvQAcHwHZ0mbJ7zcfQ==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.20",
+        "@next/env": "15.5.22",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -4370,14 +4394,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.20",
-        "@next/swc-darwin-x64": "15.5.20",
-        "@next/swc-linux-arm64-gnu": "15.5.20",
-        "@next/swc-linux-arm64-musl": "15.5.20",
-        "@next/swc-linux-x64-gnu": "15.5.20",
-        "@next/swc-linux-x64-musl": "15.5.20",
-        "@next/swc-win32-arm64-msvc": "15.5.20",
-        "@next/swc-win32-x64-msvc": "15.5.20",
+        "@next/swc-darwin-arm64": "15.5.22",
+        "@next/swc-darwin-x64": "15.5.22",
+        "@next/swc-linux-arm64-gnu": "15.5.22",
+        "@next/swc-linux-arm64-musl": "15.5.22",
+        "@next/swc-linux-x64-gnu": "15.5.22",
+        "@next/swc-linux-x64-musl": "15.5.22",
+        "@next/swc-win32-arm64-msvc": "15.5.22",
+        "@next/swc-win32-x64-msvc": "15.5.22",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -4744,9 +4768,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4761,8 +4785,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6681,9 +6706,9 @@
       }
     },
     "@next/env": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.20.tgz",
-      "integrity": "sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw=="
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.22.tgz",
+      "integrity": "sha512-O5BlKb3KtsHkvO0gjjV66PuJnAgCtIEIzwkt50HRAHsQkU1t77eksIXSZV84/WMtZJjWrnDUPKHVRi0D62nSAA=="
     },
     "@next/eslint-plugin-next": {
       "version": "15.5.20",
@@ -6719,51 +6744,51 @@
       }
     },
     "@next/swc-darwin-arm64": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.20.tgz",
-      "integrity": "sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.22.tgz",
+      "integrity": "sha512-/VISwtffSg8+fVvBbXdglsvruCsdbBC4dG25iU6xascKVqfQKsj/OtjGnOEkIS7pX5GB9e9/r5QprpicsGL3gw==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.20.tgz",
-      "integrity": "sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.22.tgz",
+      "integrity": "sha512-NiA9ve8hbiuhG/Q17a2mZDRVxMTtg3rTOgjLnDaLlE+AEPAQlkkuKrfePEbeOrgYmX0U2KGX4EVEn09hXU5GlQ==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.20.tgz",
-      "integrity": "sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.22.tgz",
+      "integrity": "sha512-vAPa9vltW+UW/KWtjXeSUFgV3wb1x9d/BeyC6WFI6eBpL0D2f70oGwtOp6193mNW3qusrpgBzMQferPf+Zh8Dw==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.20.tgz",
-      "integrity": "sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.22.tgz",
+      "integrity": "sha512-iknK80pWlNDnkdSr13bd8mMuG3Z2oTxODwsZHvuMY7caMk77+rBLdHVWsy8v2EVa3ZojJ/+wJX5fnq8va6Gv8A==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.20.tgz",
-      "integrity": "sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.22.tgz",
+      "integrity": "sha512-penuEdkwU2OOAiS+n4LE8T/VIoCfAI01QcLZTJ2xc3+l4Q22L/DzURocmI2LU1b+8BMQoLAP1Sze3uYAZT05Bg==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.20.tgz",
-      "integrity": "sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.22.tgz",
+      "integrity": "sha512-ZM0BKJm3FZ+guG6WT6PcyOLtp6paZ5tngcJC/uUKvLW4Y0TQnnVi1+UGdo8Q6Yxp5gaS82pmC1rD/oFlhkWB3g==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.20.tgz",
-      "integrity": "sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.22.tgz",
+      "integrity": "sha512-rY/YaumrZaS0//94BnHLF5VSRp0GFUO4GvXNuoCBb0cGSci96yO+p1JaNL2aq9YZAYv9cuZRziV02x5IQH/wjg==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.20.tgz",
-      "integrity": "sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.22.tgz",
+      "integrity": "sha512-s5IA4cyrbR2XK/5NWcu5dp8CfPBiKME+UhvNperia7uQybEgg5+LIhGMiY37WQE4rcI4owsDcU4IVUjLoTuDkA==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -7438,9 +7463,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -9104,9 +9129,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="
     },
     "napi-postinstall": {
       "version": "0.3.4",
@@ -9127,19 +9152,19 @@
       "dev": true
     },
     "next": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.20.tgz",
-      "integrity": "sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.22.tgz",
+      "integrity": "sha512-mrtal1sRxO4YrlDS98sDuIvGZivKbFix8w7oAL9ZynfOgc3cADQOQgvwtMooc18Qr8bKzvQAcHwHZ0mbJ7zcfQ==",
       "requires": {
-        "@next/env": "15.5.20",
-        "@next/swc-darwin-arm64": "15.5.20",
-        "@next/swc-darwin-x64": "15.5.20",
-        "@next/swc-linux-arm64-gnu": "15.5.20",
-        "@next/swc-linux-arm64-musl": "15.5.20",
-        "@next/swc-linux-x64-gnu": "15.5.20",
-        "@next/swc-linux-x64-musl": "15.5.20",
-        "@next/swc-win32-arm64-msvc": "15.5.20",
-        "@next/swc-win32-x64-msvc": "15.5.20",
+        "@next/env": "15.5.22",
+        "@next/swc-darwin-arm64": "15.5.22",
+        "@next/swc-darwin-x64": "15.5.22",
+        "@next/swc-linux-arm64-gnu": "15.5.22",
+        "@next/swc-linux-arm64-musl": "15.5.22",
+        "@next/swc-linux-x64-gnu": "15.5.22",
+        "@next/swc-linux-x64-musl": "15.5.22",
+        "@next/swc-win32-arm64-msvc": "15.5.22",
+        "@next/swc-win32-x64-msvc": "15.5.22",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "^8.5.6",
@@ -9385,11 +9410,11 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "requires": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@clerk/nextjs": "^7.5.12",
     "@vercel/analytics": "^2.0.1",
-    "next": "15.5.20",
+    "next": "15.5.22",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "zod": "^4.4.3"

--- a/src/components/ChapterComposer.tsx
+++ b/src/components/ChapterComposer.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useRef, useState } from "react";
+import { SEGMENTATION_MODES } from "../lib/segmentation-modes.mjs";
+
+export type ChapterMode = "standard" | "gpt-5.6-layout";
+
+const modes = SEGMENTATION_MODES as ReadonlyArray<{
+  id: ChapterMode;
+  label: string;
+  tier: "free" | "pro";
+  description: string;
+  showsCrown: boolean;
+}>;
+
+type Props = {
+  disabled: boolean;
+  mode: ChapterMode;
+  onModeChange: (mode: ChapterMode) => void;
+  onSubmit: (url: string) => void;
+  url: string;
+  onUrlChange: (url: string) => void;
+};
+
+export default function ChapterComposer({
+  disabled,
+  mode,
+  onModeChange,
+  onSubmit,
+  url,
+  onUrlChange,
+}: Props) {
+  const [isMenuOpen, setMenuOpen] = useState(false);
+  const menu = useRef<HTMLDivElement>(null);
+  const selected = modes.find((item) => item.id === mode);
+
+  useEffect(() => {
+    function closeMenu(event: MouseEvent) {
+      if (!menu.current?.contains(event.target as Node)) setMenuOpen(false);
+    }
+    document.addEventListener("mousedown", closeMenu);
+    return () => document.removeEventListener("mousedown", closeMenu);
+  }, []);
+
+  if (!selected) return null;
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit(url);
+      }}
+      aria-busy={disabled}
+    >
+      <label htmlFor="chapter-url" className="sr-only">
+        Chapter URL
+      </label>
+      <textarea
+        id="chapter-url"
+        rows={4}
+        inputMode="url"
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
+        required
+        disabled={disabled}
+        value={url}
+        onChange={(event) => onUrlChange(event.target.value)}
+        placeholder="Paste a chapter link…"
+        className="block w-full resize-none border-0 bg-transparent px-5 pt-5 text-lg text-gray-950 placeholder:text-gray-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed disabled:text-gray-500"
+      />
+      <div className="flex items-end justify-between gap-3 border-t border-gray-200 px-4 py-3">
+        <div ref={menu} className="relative">
+          <button
+            type="button"
+            aria-haspopup="listbox"
+            aria-expanded={isMenuOpen}
+            aria-controls="chapter-mode-menu"
+            disabled={disabled}
+            onClick={() => setMenuOpen((open) => !open)}
+            className="rounded-lg px-3 py-2 text-left text-sm font-bold text-gray-900 hover:bg-gray-100 disabled:cursor-not-allowed"
+          >
+            {selected.showsCrown && <span aria-hidden="true">♛ </span>}
+            {selected.label}
+            <span aria-hidden="true" className="ml-2 text-gray-500">
+              ⌄
+            </span>
+          </button>
+          {isMenuOpen && (
+            <div
+              id="chapter-mode-menu"
+              role="listbox"
+              aria-label="Panel detection mode"
+              className="absolute bottom-full left-0 z-10 mb-2 w-72 overflow-hidden rounded-xl border border-gray-200 bg-white p-1 shadow-xl"
+            >
+              {modes.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  role="option"
+                  aria-selected={mode === item.id}
+                  onClick={() => {
+                    onModeChange(item.id);
+                    setMenuOpen(false);
+                  }}
+                  className="block w-full rounded-lg px-3 py-3 text-left hover:bg-gray-100"
+                >
+                  <span className="flex items-center justify-between gap-3 font-bold">
+                    <span>
+                      {item.showsCrown && <span aria-hidden="true">♛ </span>}
+                      {item.label}
+                    </span>
+                    <span className="text-xs uppercase tracking-wide text-gray-500">
+                      {item.tier === "pro" ? "Pro" : "Free"}
+                    </span>
+                  </span>
+                  <span className="mt-1 block text-sm font-normal text-gray-600">
+                    {item.description}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <button
+          type="submit"
+          disabled={disabled}
+          aria-label={disabled ? "Processing chapter" : "Process chapter"}
+          className="grid h-11 w-11 place-items-center rounded-full bg-gray-950 text-xl font-bold text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:bg-gray-400"
+        >
+          <span aria-hidden="true">{disabled ? "…" : "↑"}</span>
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,8 +4,112 @@ import {
   SignUpButton,
   UserButton,
   UserName,
+  useAuth,
 } from "../lib/auth";
 import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import {
+  createBillingPortal,
+  createCheckout,
+  getSubscription,
+} from "../lib/api";
+import { trackMarketingEvent } from "../lib/analytics";
+
+function SubscriptionManagement() {
+  const { getToken, isLoaded, isSignedIn } = useAuth();
+  const [subscription, setSubscription] = useState(null);
+  const [error, setError] = useState(null);
+  const [isLoading, setLoading] = useState(false);
+
+  const loadSubscription = useCallback(async () => {
+    if (!isLoaded || !isSignedIn) {
+      setSubscription(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const token = await getToken();
+      if (!token)
+        throw new Error("Your session expired. Please sign in again.");
+      setSubscription(await getSubscription(token));
+    } catch (error) {
+      setError(
+        error instanceof Error
+          ? error.message
+          : "Could not check your subscription.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [getToken, isLoaded, isSignedIn]);
+
+  useEffect(() => {
+    void loadSubscription();
+  }, [loadSubscription]);
+
+  async function openBilling() {
+    setLoading(true);
+    setError(null);
+    const eventName = subscription?.active
+      ? "billing_portal_opened"
+      : "checkout_started";
+    trackMarketingEvent(eventName, { source: "header" });
+    try {
+      const token = await getToken();
+      if (!token)
+        throw new Error("Your session expired. Please sign in again.");
+      const url = subscription?.active
+        ? await createBillingPortal(token)
+        : await createCheckout(token);
+      trackMarketingEvent(
+        subscription?.active
+          ? "billing_portal_redirect_created"
+          : "checkout_redirect_created",
+        { source: "header" },
+      );
+      window.location.assign(url);
+    } catch (error) {
+      setError(
+        error instanceof Error ? error.message : "Could not open billing.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        type="button"
+        disabled={isLoading || !subscription}
+        onClick={() => void openBilling()}
+        className="rounded-md border border-gray-300 px-3 py-2 text-sm font-semibold text-gray-800 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isLoading
+          ? "Checking billing…"
+          : subscription?.active
+            ? "Manage subscription"
+            : "Upgrade to Pro"}
+      </button>
+      {error && (
+        <div className="flex items-center gap-2" role="alert">
+          <span className="max-w-64 text-right text-xs font-medium text-red-700">
+            {error}
+          </span>
+          <button
+            type="button"
+            onClick={() => void loadSubscription()}
+            className="text-xs font-semibold text-red-800 underline"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
 
 const Header = () => {
   return (
@@ -44,6 +148,7 @@ const Header = () => {
             </SignUpButton>
           </Show>
           <Show when="signed-in">
+            <SubscriptionManagement />
             <UserName />
             <UserButton />
           </Show>

--- a/src/components/InputForm.jsx
+++ b/src/components/InputForm.jsx
@@ -11,12 +11,16 @@ const InputForm = ({ childToParent, disabled = false }) => {
   return (
     <form onSubmit={handleSubmit} className="space-y-3">
       <input
-        type="url"
+        type="text"
+        inputMode="url"
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck="false"
         required
         disabled={disabled}
         value={url}
         onChange={(e) => setUrl(e.target.value)}
-        placeholder="Paste an https://opchapters.com chapter URL"
+        placeholder="Paste a chapter link"
         className="w-full rounded-md border border-gray-300 bg-white px-4 py-3 text-gray-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500"
       />
       <button

--- a/src/components/UpgradeModal.tsx
+++ b/src/components/UpgradeModal.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef } from "react";
+import { SignInButton, SignUpButton } from "../lib/auth";
+
+type Props = {
+  isSignedIn: boolean;
+  isLoading: boolean;
+  onClose: () => void;
+  onContinue: () => void;
+  onAuthenticate: () => void;
+};
+
+export default function UpgradeModal({
+  isSignedIn,
+  isLoading,
+  onClose,
+  onContinue,
+  onAuthenticate,
+}: Props) {
+  const closeButton = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    closeButton.current?.focus();
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && !isLoading) onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isLoading, onClose]);
+
+  return (
+    <div
+      role="presentation"
+      className="fixed inset-0 z-50 grid place-items-center bg-gray-950/55 p-4"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget && !isLoading) onClose();
+      }}
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="upgrade-title"
+        className="w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-sm font-bold text-emerald-700">OnePanel Pro</p>
+            <h2 id="upgrade-title" className="mt-1 text-2xl font-black">
+              Unlock GPT-5.6 Layout
+            </h2>
+          </div>
+          <button
+            ref={closeButton}
+            type="button"
+            aria-label="Close upgrade dialog"
+            disabled={isLoading}
+            onClick={onClose}
+            className="rounded-md p-2 text-gray-600 hover:bg-gray-100"
+          >
+            ×
+          </button>
+        </div>
+        <p className="mt-3 text-gray-700">
+          Get better panel detection for complex page layouts for €4.99 / month.
+          Cancel any time.
+        </p>
+        <div className="mt-6 grid gap-3">
+          {isSignedIn ? (
+            <button
+              type="button"
+              disabled={isLoading}
+              onClick={onContinue}
+              className="rounded-lg bg-gray-950 px-4 py-3 font-bold text-white disabled:bg-gray-400"
+            >
+              {isLoading ? "Opening Checkout…" : "Continue to Checkout"}
+            </button>
+          ) : (
+            <>
+              <SignUpButton forceRedirectUrl="/reader">
+                <button
+                  type="button"
+                  onClick={onAuthenticate}
+                  className="rounded-lg bg-gray-950 px-4 py-3 font-bold text-white"
+                >
+                  Create account and continue
+                </button>
+              </SignUpButton>
+              <SignInButton forceRedirectUrl="/reader">
+                <button
+                  type="button"
+                  onClick={onAuthenticate}
+                  className="rounded-lg border border-gray-300 px-4 py-3 font-bold text-gray-900"
+                >
+                  Sign in and continue
+                </button>
+              </SignInButton>
+            </>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,10 @@
 import { z } from "zod";
+import {
+  DEFAULT_SEGMENTATION_MODE,
+  segmentationModeSchema,
+} from "./segmentation-modes.mjs";
+
+export type SegmentationMode = z.infer<typeof segmentationModeSchema>;
 
 const panelSchema = z.object({
   path: z.string().min(1),
@@ -16,6 +22,14 @@ const chapterSchema = z.object({
 const chapterCreatedSchema = z.object({
   chapter_hash: z.string().min(1),
 });
+
+const accessErrorCodeSchema = z.enum([
+  "sign_in_required",
+  "subscription_required",
+]);
+
+export type ApiErrorCode = z.infer<typeof accessErrorCodeSchema>;
+export type ApiAccessState = "sign-in-required" | "subscription-required";
 
 const subscriptionSchema = z.object({
   active: z.boolean(),
@@ -35,18 +49,27 @@ const API_TIMEOUT_MS = 120_000;
 const API_PROXY_PATH = "/api/onepanel";
 
 export class ApiError extends Error {
+  readonly status?: number;
+  readonly code?: ApiErrorCode;
+  readonly accessState?: ApiAccessState;
+
   constructor(
     message: string,
-    public readonly status?: number,
+    status?: number,
+    code?: ApiErrorCode,
+    accessState?: ApiAccessState,
   ) {
     super(message);
     this.name = "ApiError";
+    this.status = status;
+    this.code = code;
+    this.accessState = accessState;
   }
 }
 
 async function request(
   path: string,
-  token: string,
+  token?: string | null,
   init?: RequestInit,
 ): Promise<unknown> {
   const controller = new AbortController();
@@ -60,7 +83,7 @@ async function request(
         signal: controller.signal,
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
           ...init?.headers,
         },
       },
@@ -73,16 +96,33 @@ async function request(
       } catch {
         detail = null;
       }
-      const message =
-        detail &&
-        typeof detail === "object" &&
-        "detail" in detail &&
-        typeof detail.detail === "string"
+      const errorDetail =
+        detail && typeof detail === "object" && "detail" in detail
           ? detail.detail
-          : `The API returned ${response.status} ${response.statusText}.`;
+          : detail;
+      const errorRecord =
+        errorDetail && typeof errorDetail === "object" ? errorDetail : null;
+      const codeResult = accessErrorCodeSchema.safeParse(
+        errorRecord && "code" in errorRecord ? errorRecord.code : undefined,
+      );
+      const message =
+        typeof errorDetail === "string"
+          ? errorDetail
+          : errorRecord &&
+              "message" in errorRecord &&
+              typeof errorRecord.message === "string"
+            ? errorRecord.message
+            : `The API returned ${response.status} ${response.statusText}.`;
+      const accessState = codeResult.success
+        ? codeResult.data === "sign_in_required"
+          ? "sign-in-required"
+          : "subscription-required"
+        : undefined;
       throw new ApiError(
         message,
         response.status,
+        codeResult.success ? codeResult.data : undefined,
+        accessState,
       );
     }
 
@@ -117,18 +157,23 @@ function parseResponse<T>(schema: z.ZodType<T>, value: unknown): T {
 
 export async function createChapter(
   chapterUrl: string,
-  token: string,
+  mode: SegmentationMode = DEFAULT_SEGMENTATION_MODE,
+  token?: string | null,
 ): Promise<string> {
+  const validatedMode = segmentationModeSchema.parse(mode);
   const value = await request("/v2/chapter", token, {
     method: "POST",
-    body: JSON.stringify({ chapter_url: chapterUrl }),
+    body: JSON.stringify({
+      chapter_url: chapterUrl,
+      segmentation_mode: validatedMode,
+    }),
   });
   return parseResponse(chapterCreatedSchema, value).chapter_hash;
 }
 
 export async function getChapter(
   hash: string,
-  token: string,
+  token?: string | null,
 ): Promise<Chapter> {
   const value = await request(
     `/v2/chapter/${encodeURIComponent(hash)}`,

--- a/src/lib/chapter-access.mjs
+++ b/src/lib/chapter-access.mjs
@@ -1,0 +1,10 @@
+export const SIGN_IN_REQUIRED_CODE = "sign_in_required";
+
+export function isChapterSignInRequired(error, isSignedIn) {
+  if (isSignedIn || !error || typeof error !== "object") return false;
+
+  return (
+    error.code === SIGN_IN_REQUIRED_CODE ||
+    (error.status === 401 && error.code == null)
+  );
+}

--- a/src/lib/chapter-url.mjs
+++ b/src/lib/chapter-url.mjs
@@ -1,0 +1,41 @@
+const MARKDOWN_LINK_PATTERN = /^\[[^\]]*\]\(\s*(\S+?)\s*\)$/;
+
+/**
+ * Normalize the common forms in which readers paste chapter links.
+ *
+ * Source support belongs to the API: the frontend only verifies that the input
+ * is a safe HTTP(S) URL and sends the normalized URL through unchanged.
+ */
+export function normalizeChapterUrl(value) {
+  if (typeof value !== "string") return null;
+
+  let candidate = value.trim();
+  const markdownLink = candidate.match(MARKDOWN_LINK_PATTERN);
+  if (markdownLink) candidate = markdownLink[1];
+
+  if (candidate.startsWith("<") && candidate.endsWith(">")) {
+    candidate = candidate.slice(1, -1).trim();
+  }
+
+  if (candidate.startsWith("//")) {
+    candidate = `https:${candidate}`;
+  } else if (!/^[a-z][a-z\d+.-]*:/i.test(candidate)) {
+    candidate = `https://${candidate}`;
+  }
+
+  try {
+    const url = new URL(candidate);
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      !url.hostname ||
+      url.username ||
+      url.password
+    ) {
+      return null;
+    }
+
+    return url.href;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/pending-chapter-request.mjs
+++ b/src/lib/pending-chapter-request.mjs
@@ -1,0 +1,88 @@
+export const PENDING_CHAPTER_REQUEST_KEY =
+  "onepanel.pending-chapter-request.v1";
+
+const VERSION = 1;
+const CONTINUATIONS = new Set(["authenticate", "checkout", "restore"]);
+
+export function parsePendingChapterRequest(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+
+  const keys = Object.keys(value);
+  if (
+    keys.length !== 4 ||
+    !keys.every((key) =>
+      ["version", "url", "mode", "continuation"].includes(key),
+    )
+  ) {
+    return null;
+  }
+
+  if (
+    value.version !== VERSION ||
+    typeof value.url !== "string" ||
+    value.url.length === 0 ||
+    value.url.length > 4096 ||
+    !segmentationModeSchema.safeParse(value.mode).success ||
+    !CONTINUATIONS.has(value.continuation)
+  ) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value.url);
+    if (!["http:", "https:"].includes(url.protocol) || url.username)
+      return null;
+  } catch {
+    return null;
+  }
+
+  return {
+    version: VERSION,
+    url: value.url,
+    mode: value.mode,
+    continuation: value.continuation,
+  };
+}
+
+export function readPendingChapterRequest(storage) {
+  if (!storage) return null;
+
+  try {
+    const raw = storage.getItem(PENDING_CHAPTER_REQUEST_KEY);
+    if (!raw) return null;
+    const parsed = parsePendingChapterRequest(JSON.parse(raw));
+    if (!parsed) storage.removeItem(PENDING_CHAPTER_REQUEST_KEY);
+    return parsed;
+  } catch {
+    try {
+      storage.removeItem(PENDING_CHAPTER_REQUEST_KEY);
+    } catch {
+      // Storage can be unavailable in privacy-restricted browsing contexts.
+    }
+    return null;
+  }
+}
+
+export function writePendingChapterRequest(storage, request) {
+  const parsed = parsePendingChapterRequest({
+    version: VERSION,
+    ...request,
+  });
+  if (!storage || !parsed) return false;
+
+  try {
+    storage.setItem(PENDING_CHAPTER_REQUEST_KEY, JSON.stringify(parsed));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearPendingChapterRequest(storage) {
+  try {
+    storage?.removeItem(PENDING_CHAPTER_REQUEST_KEY);
+  } catch {
+    // The UI still works if session storage is unavailable.
+  }
+}
+import { segmentationModeSchema } from "./segmentation-modes.mjs";

--- a/src/lib/segmentation-modes.mjs
+++ b/src/lib/segmentation-modes.mjs
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export const segmentationModeSchema = z.enum(["standard", "gpt-5.6-layout"]);
+
+export const DEFAULT_SEGMENTATION_MODE = "standard";
+
+export const SEGMENTATION_MODES = [
+  {
+    id: "standard",
+    label: "Standard",
+    description: "Fast local panel detection for everyday page layouts.",
+    tier: "free",
+    showsCrown: false,
+  },
+  {
+    id: "gpt-5.6-layout",
+    label: "GPT-5.6 Layout",
+    description: "Better panel detection for complex page layouts.",
+    tier: "pro",
+    showsCrown: true,
+  },
+];
+
+/** @param {unknown} value */
+export function parseSegmentationMode(value) {
+  return segmentationModeSchema.parse(value);
+}
+
+/** @param {unknown} value */
+export function findSegmentationMode(value) {
+  const parsed = segmentationModeSchema.safeParse(value);
+  return parsed.success
+    ? SEGMENTATION_MODES.find((mode) => mode.id === parsed.data)
+    : undefined;
+}

--- a/src/pages/chapter/[hash].jsx
+++ b/src/pages/chapter/[hash].jsx
@@ -6,6 +6,7 @@ import Head from "next/head";
 import LoadingComponent from "../../components/Loading";
 import ErrorMessage from "../../components/ErrorMessage";
 import { getChapter } from "../../lib/api";
+import { isChapterSignInRequired } from "../../lib/chapter-access.mjs";
 
 export default function Page() {
   const router = useRouter();
@@ -15,28 +16,31 @@ export default function Page() {
   const [data, setData] = useState(null);
   const [isLoading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [requiresSignIn, setRequiresSignIn] = useState(false);
   const { getToken, isLoaded, isSignedIn } = useAuth();
 
   const loadChapter = useCallback(async () => {
     if (!router.isReady || !isLoaded) return;
-    if (!isSignedIn) {
-      setLoading(false);
-      setError("Sign in with an active subscription to read this chapter.");
-      return;
-    }
     if (!chapterHash) return;
 
     setLoading(true);
     setError(null);
+    setRequiresSignIn(false);
     setData(null);
     try {
-      const token = await getToken();
-      if (!token)
+      const token = isSignedIn ? await getToken() : null;
+      if (isSignedIn && !token)
         throw new Error("Your session expired. Please sign in again.");
       setData(await getChapter(chapterHash, token));
     } catch (error) {
+      const accountRequired = isChapterSignInRequired(error, isSignedIn);
+      setRequiresSignIn(accountRequired);
       setError(
-        error instanceof Error ? error.message : "Could not load the chapter.",
+        accountRequired
+          ? "This GPT-5.6 chapter requires an account. Sign in to continue reading."
+          : error instanceof Error
+            ? error.message
+            : "Could not load the chapter.",
       );
     } finally {
       setLoading(false);
@@ -63,10 +67,13 @@ export default function Page() {
         {error && (
           <div className="space-y-4 text-center">
             <ErrorMessage message={error} onRetry={loadChapter} />
-            {!isSignedIn && (
-              <SignInButton>
+            {requiresSignIn && chapterHash && (
+              <SignInButton
+                fallbackRedirectUrl={`/chapter/${encodeURIComponent(chapterHash)}`}
+                signUpFallbackRedirectUrl={`/chapter/${encodeURIComponent(chapterHash)}`}
+              >
                 <button className="rounded-md bg-blue-600 px-4 py-2 font-semibold text-white">
-                  Sign in
+                  Sign in to read
                 </button>
               </SignInButton>
             )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -56,7 +56,7 @@ const Home: NextPage = () => {
         <title>OnePanel Reader</title>
         <meta
           name="description"
-          content="Read manga chapters one panel at a time. OnePanel Reader turns OP Chapters links into a focused spoiler-safe reading flow."
+          content="Read manga chapters one panel at a time. OnePanel Reader turns chapter links into a focused spoiler-safe reading flow."
         />
         <meta
           property="og:title"
@@ -64,7 +64,7 @@ const Home: NextPage = () => {
         />
         <meta
           property="og:description"
-          content="Paste an OP Chapters URL and read every chapter one panel at a time."
+          content="Paste a manga chapter URL and read every chapter one panel at a time."
         />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://onepanel.app" />

--- a/src/pages/reader.tsx
+++ b/src/pages/reader.tsx
@@ -2,23 +2,30 @@ import { type NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
+import ChapterComposer, {
+  type ChapterMode,
+} from "../components/ChapterComposer";
 import ErrorMessage from "../components/ErrorMessage";
 import Footer from "../components/Footer";
 import Header from "../components/Header";
-import InputForm from "../components/InputForm";
-import LoadingComponent from "../components/Loading";
-import { Show, SignInButton, SignUpButton, useAuth } from "../lib/auth";
+import UpgradeModal from "../components/UpgradeModal";
+import { useAuth } from "../lib/auth";
 import { trackMarketingEvent } from "../lib/analytics";
 import {
-  createBillingPortal,
   createChapter,
   createCheckout,
   getSubscription,
   type Subscription,
 } from "../lib/api";
+import { normalizeChapterUrl } from "../lib/chapter-url.mjs";
+import {
+  clearPendingChapterRequest,
+  readPendingChapterRequest,
+  writePendingChapterRequest,
+} from "../lib/pending-chapter-request.mjs";
 
 const readerBenefits = [
-  "Paste an OP Chapters link.",
+  "Paste a chapter link from your reader.",
   "Read one panel at a time.",
   "Keep future panels off-screen.",
 ];
@@ -28,6 +35,10 @@ const Reader: NextPage = () => {
   const [error, setError] = useState<string | null>(null);
   const [subscription, setSubscription] = useState<Subscription | null>(null);
   const [isBillingLoading, setBillingLoading] = useState(false);
+  const [url, setUrl] = useState("");
+  const [mode, setMode] = useState<ChapterMode>("standard");
+  const [isUpgradeOpen, setUpgradeOpen] = useState(false);
+  const [hasRestored, setHasRestored] = useState(false);
   const router = useRouter();
   const { getToken, isLoaded, isSignedIn } = useAuth();
 
@@ -60,32 +71,97 @@ const Reader: NextPage = () => {
     void loadSubscription();
   }, [loadSubscription]);
 
-  function isValidChapterUrl(chapterUrl: string) {
-    try {
-      const url = new URL(chapterUrl);
-      return url.protocol === "https:" && url.hostname === "opchapters.com";
-    } catch {
-      return false;
+  const redirectToCheckout = useCallback(
+    async (chapterUrl: string, chapterMode: ChapterMode) => {
+      setBillingLoading(true);
+      setError(null);
+      trackMarketingEvent("checkout_continuation", {
+        mode: chapterMode,
+        stage: "started",
+      });
+      try {
+        const token = await getToken();
+        if (!token)
+          throw new Error("Your session expired. Please sign in again.");
+        writePendingChapterRequest(window.sessionStorage, {
+          url: chapterUrl,
+          mode: chapterMode,
+          continuation: "restore",
+        });
+        const checkoutUrl = await createCheckout(token);
+        trackMarketingEvent("checkout_continuation", {
+          mode: chapterMode,
+          stage: "redirect_created",
+        });
+        window.location.assign(checkoutUrl);
+      } catch (error) {
+        setError(
+          error instanceof Error
+            ? error.message
+            : "Could not open Stripe Checkout.",
+        );
+      } finally {
+        setBillingLoading(false);
+      }
+    },
+    [getToken],
+  );
+
+  useEffect(() => {
+    if (!isLoaded || hasRestored) return;
+    const pending = readPendingChapterRequest(window.sessionStorage);
+    setHasRestored(true);
+    if (!pending) return;
+
+    setUrl(pending.url);
+    setMode(pending.mode);
+    if (pending.continuation === "authenticate" && isSignedIn) {
+      trackMarketingEvent("authentication_continuation", {
+        mode: pending.mode,
+        stage: "authenticated",
+      });
+      writePendingChapterRequest(window.sessionStorage, {
+        url: pending.url,
+        mode: pending.mode,
+        continuation: "checkout",
+      });
+      void redirectToCheckout(pending.url, pending.mode);
     }
-  }
+  }, [hasRestored, isLoaded, isSignedIn, redirectToCheckout]);
 
   async function postUrl(chapterUrl: string) {
-    if (!isValidChapterUrl(chapterUrl)) {
-      setError("Enter a valid https://opchapters.com chapter URL.");
+    const normalizedChapterUrl = normalizeChapterUrl(chapterUrl);
+    if (!normalizedChapterUrl) {
+      setError("Enter a valid chapter link.");
+      return;
+    }
+
+    if (mode === "gpt-5.6-layout" && !subscription?.active) {
+      setUrl(normalizedChapterUrl);
+      setUpgradeOpen(true);
+      trackMarketingEvent("upgrade_displayed", {
+        mode,
+        signed_in: isSignedIn,
+      });
       return;
     }
 
     setLoading(true);
     setError(null);
     trackMarketingEvent("chapter_url_submitted", {
+      mode,
       source: "reader_page",
     });
     try {
-      const token = await getToken();
-      if (!token)
-        throw new Error("Your session expired. Please sign in again.");
-      const chapterHash = await createChapter(chapterUrl, token);
+      const token = isSignedIn ? await getToken() : null;
+      const chapterHash = await createChapter(
+        normalizedChapterUrl,
+        mode,
+        token,
+      );
+      clearPendingChapterRequest(window.sessionStorage);
       trackMarketingEvent("chapter_created", {
+        mode,
         source: "reader_page",
       });
       await router.push(`/chapter/${chapterHash}`);
@@ -98,50 +174,13 @@ const Reader: NextPage = () => {
     }
   }
 
-  async function redirectToBilling(destination: "checkout" | "portal") {
-    setBillingLoading(true);
-    setError(null);
-    trackMarketingEvent(
-      destination === "checkout" ? "checkout_started" : "billing_portal_opened",
-      {
-        source: "reader_page",
-      },
-    );
-    try {
-      const token = await getToken();
-      if (!token)
-        throw new Error("Your session expired. Please sign in again.");
-      const url =
-        destination === "checkout"
-          ? await createCheckout(token)
-          : await createBillingPortal(token);
-      trackMarketingEvent(
-        destination === "checkout"
-          ? "checkout_redirect_created"
-          : "billing_portal_redirect_created",
-        {
-          source: "reader_page",
-        },
-      );
-      window.location.assign(url);
-    } catch (error) {
-      setError(
-        error instanceof Error
-          ? error.message
-          : "Could not open Stripe billing.",
-      );
-    } finally {
-      setBillingLoading(false);
-    }
-  }
-
   return (
     <>
       <Head>
         <title>Reader | OnePanel Reader</title>
         <meta
           name="description"
-          content="Paste an OP Chapters URL and start a spoiler-safe panel-by-panel reading flow."
+          content="Paste a manga chapter URL and start a spoiler-safe panel-by-panel reading flow."
         />
         <meta name="robots" content="noindex" />
         <link rel="icon" href="/favicon.ico" />
@@ -158,100 +197,33 @@ const Reader: NextPage = () => {
                 Paste a chapter link.
               </h1>
               <p className="mx-auto mt-4 max-w-2xl text-lg leading-8 text-gray-700">
-                Drop in an{" "}
-                <a
-                  href="https://opchapters.com/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-semibold text-gray-950 underline underline-offset-4 hover:text-gray-700"
-                >
-                  OP Chapters
-                </a>{" "}
-                URL and OnePanel will open it as a focused, spoiler-safe reader.
+                Drop in a chapter URL from your manga reader and OnePanel will
+                open it as a focused, spoiler-safe reader.
               </p>
             </section>
 
-            <section className="mx-auto mt-8 rounded-md border border-gray-200 bg-white p-5 shadow-sm sm:p-6">
-              {!isLoaded && <LoadingComponent />}
-              {isLoaded && (
-                <>
-                  <Show when="signed-out">
-                    <div className="text-center">
-                      <h2 className="text-2xl font-bold">Join OnePanel Pro</h2>
-                      <p className="my-3 text-3xl font-bold">
-                        €4.99
-                        <span className="text-base font-normal"> / month</span>
-                      </p>
-                      <p className="mb-5 text-sm text-gray-700">
-                        Create an account to subscribe, process chapters, and
-                        manage billing securely through Stripe.
-                      </p>
-                      <div className="grid gap-3">
-                        <SignUpButton>
-                          <button className="w-full rounded-md bg-gray-950 px-5 py-3 font-semibold text-white hover:bg-gray-800">
-                            Subscribe now
-                          </button>
-                        </SignUpButton>
-                        <SignInButton>
-                          <button className="w-full rounded-md border border-gray-300 px-5 py-3 font-semibold text-gray-800 hover:bg-gray-100">
-                            Sign in
-                          </button>
-                        </SignInButton>
-                      </div>
-                    </div>
-                  </Show>
-                  <Show when="signed-in">
-                    {isBillingLoading && <LoadingComponent />}
-                    {!isBillingLoading && subscription?.active && (
-                      <>
-                        <InputForm
-                          childToParent={postUrl}
-                          disabled={isLoading}
-                        />
-                        {isLoading && (
-                          <p className="mt-3 text-center text-sm font-semibold text-gray-600">
-                            Preparing your panel-by-panel reader.
-                          </p>
-                        )}
-                        <button
-                          type="button"
-                          onClick={() => void redirectToBilling("portal")}
-                          className="mt-4 w-full text-sm font-semibold text-gray-900 underline underline-offset-4"
-                        >
-                          Manage subscription
-                        </button>
-                      </>
-                    )}
-                    {!isBillingLoading &&
-                      subscription &&
-                      !subscription.active && (
-                        <div className="text-center">
-                          <h2 className="text-2xl font-bold">OnePanel Pro</h2>
-                          <p className="my-3 text-3xl font-bold">
-                            €4.99
-                            <span className="text-base font-normal">
-                              {" "}
-                              / month
-                            </span>
-                          </p>
-                          <p className="mb-5 text-sm text-gray-700">
-                            Unlimited access while your subscription is active.
-                            Cancel any time. No free trial.
-                          </p>
-                          <button
-                            type="button"
-                            onClick={() => void redirectToBilling("checkout")}
-                            className="w-full rounded-md bg-gray-950 px-4 py-3 font-semibold text-white hover:bg-gray-800"
-                          >
-                            Subscribe
-                          </button>
-                        </div>
-                      )}
-                  </Show>
-                </>
+            <section className="mx-auto mt-8 overflow-visible rounded-2xl border border-gray-200 bg-white shadow-lg">
+              <ChapterComposer
+                disabled={isLoading}
+                mode={mode}
+                onModeChange={(nextMode) => {
+                  setMode(nextMode);
+                  trackMarketingEvent("mode_selected", {
+                    mode: nextMode,
+                    source: "reader_page",
+                  });
+                }}
+                onSubmit={(chapterUrl) => void postUrl(chapterUrl)}
+                url={url}
+                onUrlChange={setUrl}
+              />
+              {isLoading && (
+                <p className="border-t border-gray-100 px-5 py-3 text-center text-sm font-semibold text-gray-600">
+                  Preparing your panel-by-panel reader.
+                </p>
               )}
               {error && (
-                <div className="mt-4">
+                <div className="px-5 pb-5">
                   <ErrorMessage message={error} />
                 </div>
               )}
@@ -271,6 +243,34 @@ const Reader: NextPage = () => {
         </main>
         <Footer />
       </div>
+      {isUpgradeOpen && (
+        <UpgradeModal
+          isSignedIn={isSignedIn}
+          isLoading={isBillingLoading}
+          onClose={() => setUpgradeOpen(false)}
+          onAuthenticate={() => {
+            const normalized = normalizeChapterUrl(url);
+            trackMarketingEvent("authentication_continuation", {
+              mode,
+              stage: "started",
+            });
+            if (
+              normalized &&
+              writePendingChapterRequest(window.sessionStorage, {
+                url: normalized,
+                mode,
+                continuation: "authenticate",
+              })
+            ) {
+              setUrl(normalized);
+            }
+          }}
+          onContinue={() => {
+            const normalized = normalizeChapterUrl(url);
+            if (normalized) void redirectToCheckout(normalized, mode);
+          }}
+        />
+      )}
     </>
   );
 };

--- a/src/pages/reader.tsx
+++ b/src/pages/reader.tsx
@@ -50,18 +50,13 @@ const Reader: NextPage = () => {
     }
 
     setBillingLoading(true);
-    setError(null);
     try {
       const token = await getToken();
       if (!token)
         throw new Error("Your session expired. Please sign in again.");
       setSubscription(await getSubscription(token));
-    } catch (error) {
-      setError(
-        error instanceof Error
-          ? error.message
-          : "Could not check your subscription.",
-      );
+    } catch {
+      setSubscription(null);
     } finally {
       setBillingLoading(false);
     }

--- a/test/api.test.mjs
+++ b/test/api.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test, { afterEach } from "node:test";
+import { ApiError, createChapter, getChapter } from "../src/lib/api.ts";
+
+globalThis.window = globalThis;
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function jsonResponse(value, init = {}) {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+test("anonymous Standard chapter creation sends a validated mode without Authorization", async () => {
+  globalThis.fetch = async (_url, init) => {
+    assert.equal(new Headers(init.headers).has("Authorization"), false);
+    assert.deepEqual(JSON.parse(init.body), {
+      chapter_url: "https://example.test/chapter/1",
+      segmentation_mode: "standard",
+    });
+    return jsonResponse({ chapter_hash: "chapter-hash" });
+  };
+
+  assert.equal(
+    await createChapter("https://example.test/chapter/1"),
+    "chapter-hash",
+  );
+});
+
+test("chapter retrieval includes Authorization only when a token is available", async () => {
+  const seenAuthorization = [];
+  globalThis.fetch = async (_url, init) => {
+    seenAuthorization.push(new Headers(init.headers).get("Authorization"));
+    return jsonResponse({
+      pages: [{ image: "page.jpg", panels: [{ path: "panel.jpg" }] }],
+    });
+  };
+
+  await getChapter("public");
+  await getChapter("account-only", "chapter-token");
+  assert.deepEqual(seenAuthorization, [null, "Bearer chapter-token"]);
+});
+
+test("machine-readable access failures become stable access states", async () => {
+  globalThis.fetch = async () =>
+    jsonResponse(
+      {
+        detail: {
+          code: "sign_in_required",
+          message: "Authentication is required.",
+        },
+      },
+      { status: 401 },
+    );
+
+  await assert.rejects(getChapter("private"), (error) => {
+    assert.ok(error instanceof ApiError);
+    assert.equal(error.status, 401);
+    assert.equal(error.code, "sign_in_required");
+    assert.equal(error.accessState, "sign-in-required");
+    assert.equal(error.message, "Authentication is required.");
+    return true;
+  });
+});
+
+test("billing calls remain token-required at the type boundary", async () => {
+  globalThis.fetch = async (_url, init) => {
+    assert.equal(
+      new Headers(init.headers).get("Authorization"),
+      "Bearer billing-token",
+    );
+    return jsonResponse({ active: false, status: null });
+  };
+
+  const { getSubscription } = await import("../src/lib/api.ts");
+  await getSubscription("billing-token");
+});

--- a/test/chapter-access.test.mjs
+++ b/test/chapter-access.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isChapterSignInRequired,
+  SIGN_IN_REQUIRED_CODE,
+} from "../src/lib/chapter-access.mjs";
+
+test("signed-out readers are prompted for stable account-gated responses", () => {
+  assert.equal(
+    isChapterSignInRequired(
+      { code: SIGN_IN_REQUIRED_CODE, status: 403 },
+      false,
+    ),
+    true,
+  );
+});
+
+test("legacy unauthorized responses retain the focused sign-in flow", () => {
+  assert.equal(isChapterSignInRequired({ status: 401 }, false), true);
+});
+
+test("signed-in and unrelated failures remain ordinary visible errors", () => {
+  assert.equal(
+    isChapterSignInRequired({ code: SIGN_IN_REQUIRED_CODE, status: 401 }, true),
+    false,
+  );
+  assert.equal(isChapterSignInRequired({ status: 500 }, false), false);
+  assert.equal(
+    isChapterSignInRequired(
+      { code: "subscription_required", status: 403 },
+      false,
+    ),
+    false,
+  );
+});

--- a/test/chapter-url.test.mjs
+++ b/test/chapter-url.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeChapterUrl } from "../src/lib/chapter-url.mjs";
+
+test("accepts HTTP and HTTPS chapter URLs from any source", () => {
+  assert.equal(
+    normalizeChapterUrl("https://opchapters.com/chapter/1121?lang=en#page-3"),
+    "https://opchapters.com/chapter/1121?lang=en#page-3",
+  );
+  assert.equal(
+    normalizeChapterUrl("http://reader.example/chapter/12"),
+    "http://reader.example/chapter/12",
+  );
+});
+
+test("adds HTTPS to bare domains and protocol-relative links", () => {
+  assert.equal(
+    normalizeChapterUrl("www.reader.example/title/chapter-12"),
+    "https://www.reader.example/title/chapter-12",
+  );
+  assert.equal(
+    normalizeChapterUrl("//m.reader.example/chapter/12"),
+    "https://m.reader.example/chapter/12",
+  );
+});
+
+test("unwraps common copied-link formats", () => {
+  assert.equal(
+    normalizeChapterUrl("  <https://reader.example/chapter/12>  "),
+    "https://reader.example/chapter/12",
+  );
+  assert.equal(
+    normalizeChapterUrl("[Chapter 12](https://reader.example/chapter/12)"),
+    "https://reader.example/chapter/12",
+  );
+});
+
+test("preserves encoded, Unicode, query, and fragment URL information", () => {
+  assert.equal(
+    normalizeChapterUrl(
+      "https://例え.テスト/作品/chapter%2012?quality=high#page=3",
+    ),
+    "https://xn--r8jz45g.xn--zckzah/%E4%BD%9C%E5%93%81/chapter%2012?quality=high#page=3",
+  );
+});
+
+test("rejects malformed links, non-web schemes, and credentials", () => {
+  assert.equal(normalizeChapterUrl(""), null);
+  assert.equal(normalizeChapterUrl("not a url"), null);
+  assert.equal(normalizeChapterUrl("javascript:alert(1)"), null);
+  assert.equal(normalizeChapterUrl("ftp://reader.example/chapter/12"), null);
+  assert.equal(
+    normalizeChapterUrl("https://user:secret@reader.example/chapter/12"),
+    null,
+  );
+});

--- a/test/pending-chapter-request.test.mjs
+++ b/test/pending-chapter-request.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  PENDING_CHAPTER_REQUEST_KEY,
+  parsePendingChapterRequest,
+  readPendingChapterRequest,
+  writePendingChapterRequest,
+} from "../src/lib/pending-chapter-request.mjs";
+
+function storage(initial) {
+  const values = new Map(
+    initial ? [[PENDING_CHAPTER_REQUEST_KEY, initial]] : [],
+  );
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+  };
+}
+
+const valid = {
+  version: 1,
+  url: "https://opchapters.com/chapter/1",
+  mode: "gpt-5.6-layout",
+  continuation: "checkout",
+};
+
+test("validates the versioned minimal pending request", () => {
+  assert.deepEqual(parsePendingChapterRequest(valid), valid);
+  assert.equal(parsePendingChapterRequest({ ...valid, token: "secret" }), null);
+  assert.equal(parsePendingChapterRequest({ ...valid, version: 2 }), null);
+  assert.equal(
+    parsePendingChapterRequest({ ...valid, mode: "provider-model" }),
+    null,
+  );
+  assert.equal(
+    parsePendingChapterRequest({ ...valid, url: "javascript:alert(1)" }),
+    null,
+  );
+});
+
+test("invalid JSON is discarded from session storage", () => {
+  const target = storage("{");
+  assert.equal(readPendingChapterRequest(target), null);
+  assert.equal(target.getItem(PENDING_CHAPTER_REQUEST_KEY), null);
+});
+
+test("writes and reads only a valid request", () => {
+  const target = storage();
+  assert.equal(
+    writePendingChapterRequest(target, {
+      url: valid.url,
+      mode: valid.mode,
+      continuation: "authenticate",
+    }),
+    true,
+  );
+  assert.deepEqual(readPendingChapterRequest(target), {
+    ...valid,
+    continuation: "authenticate",
+  });
+});

--- a/test/reader-subscription-errors.test.mjs
+++ b/test/reader-subscription-errors.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("subscription-status failures do not render as composer errors", async () => {
+  const source = await readFile(
+    new URL("../src/pages/reader.tsx", import.meta.url),
+    "utf8",
+  );
+  const subscriptionLoader = source.slice(
+    source.indexOf("const loadSubscription"),
+    source.indexOf("useEffect(() =>", source.indexOf("const loadSubscription")),
+  );
+
+  assert.ok(subscriptionLoader.includes("setSubscription(null)"));
+  assert.doesNotMatch(subscriptionLoader, /\bsetError\(/);
+});

--- a/test/segmentation-modes.test.mjs
+++ b/test/segmentation-modes.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DEFAULT_SEGMENTATION_MODE,
+  SEGMENTATION_MODES,
+  findSegmentationMode,
+  parseSegmentationMode,
+} from "../src/lib/segmentation-modes.mjs";
+
+test("the mode catalog has a free default and a crowned Pro mode", () => {
+  assert.equal(DEFAULT_SEGMENTATION_MODE, "standard");
+  assert.deepEqual(
+    SEGMENTATION_MODES.map(({ id, tier, showsCrown }) => ({
+      id,
+      tier,
+      showsCrown,
+    })),
+    [
+      { id: "standard", tier: "free", showsCrown: false },
+      { id: "gpt-5.6-layout", tier: "pro", showsCrown: true },
+    ],
+  );
+});
+
+test("mode parsing rejects identifiers outside the public catalog", () => {
+  assert.equal(parseSegmentationMode("standard"), "standard");
+  assert.equal(findSegmentationMode("gpt-5.6-layout")?.tier, "pro");
+  assert.equal(findSegmentationMode("provider-model-name"), undefined);
+  assert.throws(() => parseSegmentationMode("provider-model-name"));
+});


### PR DESCRIPTION
## What changed

- replaces the reader paywall with a large chapter composer and data-driven mode selector
- makes Standard chapter creation and retrieval anonymous-capable
- adds GPT-5.6 Layout Pro selection, upgrade modal, authentication continuation, and Stripe Checkout continuation
- stores only a validated, versioned URL/mode/continuation record in session storage
- restores Checkout state without automatically submitting model work
- supports public Standard reading and focused sign-in return for account-gated GPT-5.6 chapters
- moves subscription management into the signed-in header with visible errors
- validates changed API responses and exposes stable access states
- adds privacy-safe mode/upgrade/continuation analytics without chapter URLs or content
- documents entitlements, storage lifecycle, analytics, and the deployed API contract
- updates Next.js to 15.5.22

## Why

OnePanel now offers Standard local panel detection for free without an account. GPT-5.6 Layout remains included in the €4.99/month Pro subscription for complex layouts. The deployed API is the authorization boundary.

## User impact

Signed-out users can paste an OP Chapters link, process it with Standard, and read the result. Selecting GPT-5.6 Layout preserves the composer state while guiding signed-out/free users through authentication and Checkout. Signed-in users can manage billing from the header.

## Validation

- `npm run test` — 22 passed
- `npm run lint` — passed
- `npm run build` — passed
- `git diff --check` — passed
- deployed API smoke test — anonymous Standard created/retrieved a real 14-page chapter; premium/validation errors matched the frontend contract
- `npm audit` — remains non-zero with 20 high findings in the ESLint/minimatch development chain and Next.js bundled Sharp/libvips; automated remedies require forced/breaking changes and are tracked in #54

## Tracking

Closes #35
Closes #36
Closes #37
Closes #38
Closes #39
Closes #40
Closes #41
Closes #42
Closes #43
Closes #44
Closes #45
Closes #46
Closes #47
Closes #48
Closes #49
Closes #50
Closes #51
Closes #52

Part of #19. Production rollout remains tracked in #53.
