### PR TITLE
Update communications for freemium launch

### DIFF
--- a/docs/marketing-launch-plan.md
+++ b/docs/marketing-launch-plan.md
@@ -8,10 +8,15 @@ panel at a time without accidentally seeing the rest of the page.
 
 Primary offer:
 
-- OnePanel Pro
-- €4.99 per month
-- Unlimited access while subscribed
-- Cancel any time
+- Standard mode is free
+- No account or card required
+- OnePanel Pro adds GPT-5.6 Layout for complex pages
+- €4.99 per month, cancel any time
+
+Core message:
+
+Read manga one panel at a time for free. Upgrade to Pro only when you want
+better panel detection for complex page layouts.
 
 ## Launch goals
 
@@ -111,14 +116,16 @@ Body:
 
 Hi,
 
-Quick final reminder: the new OnePanel Reader is live.
+Quick final reminder: the new OnePanel Reader is live, and Standard mode is
+free.
 
 If you read OP Chapters and want a cleaner, spoiler-safe panel-by-panel flow,
-you can subscribe here:
+you can start here without an account or card:
 
 https://onepanel.app
 
-It is €4.99 per month, with billing handled by Stripe.
+For complex page layouts, Pro adds GPT-5.6 Layout for €4.99 per month, with
+billing handled by Stripe.
 
 Thanks again for checking it out.
 
@@ -137,7 +144,8 @@ Format ideas:
 
 Caption template:
 
-Read OP Chapters one panel at a time. OnePanel Reader is live now for €4.99/mo.
+Read OP Chapters one panel at a time for free. Upgrade to Pro for better
+detection on complex layouts.
 
 Channels:
 
@@ -185,7 +193,8 @@ I kept running into the same problem when reading manga online: full pages often
 show the next reveal before I am ready for it. I built OnePanel Reader to paste
 an OP Chapters link and read the chapter one panel at a time.
 
-The new version is live, faster than the prototype, and costs €4.99/month.
+The new version is live, faster than the prototype, and free to use in
+Standard mode. Pro adds better detection for complex layouts for €4.99/month.
 Feedback is welcome, especially from people who read on desktop or tablet.
 
 ## Metrics to review every week

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -13,9 +13,11 @@ arrow-key navigation.
 ## Key facts
 
 - OnePanel Reader works with chapter links from https://opchapters.com/.
-- Pricing: OnePanel Pro is EUR 4.99 per month, no free trial, cancel any
-  time. Billing is handled by Stripe.
-- Sign in is required to create and read chapters (Clerk authentication).
+- Pricing: Standard mode is free with no account or card required. OnePanel
+  Pro is EUR 4.99 per month, adds GPT-5.6 Layout for complex pages, and can be
+  cancelled any time. Billing is handled by Stripe.
+- Standard chapters can be created and read without signing in. An account and
+  active subscription are required for GPT-5.6 Layout creation.
 - OnePanel Reader is a web app at https://onepanel.app, not a native app.
 
 ## Pages

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,11 +1,4 @@
-import {
-  Show,
-  SignInButton,
-  SignUpButton,
-  UserButton,
-  UserName,
-  useAuth,
-} from "../lib/auth";
+import { Show, SignInButton, UserButton, UserName, useAuth } from "../lib/auth";
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import {
@@ -136,16 +129,17 @@ const Header = () => {
         </div>
         <div className="flex items-center gap-3">
           <Show when="signed-out">
+            <Link
+              href="/reader"
+              className="rounded-md bg-gray-950 px-3 py-2 font-semibold text-white hover:bg-gray-800"
+            >
+              Read free
+            </Link>
             <SignInButton>
               <button className="rounded-md border border-gray-300 px-3 py-2 font-semibold text-gray-800 hover:bg-gray-100">
                 Sign in
               </button>
             </SignInButton>
-            <SignUpButton>
-              <button className="rounded-md bg-gray-950 px-3 py-2 font-semibold text-white hover:bg-gray-800">
-                Create account
-              </button>
-            </SignUpButton>
           </Show>
           <Show when="signed-in">
             <SubscriptionManagement />

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -23,7 +23,7 @@ const faqs = [
   {
     question: "How much does OnePanel Reader cost?",
     answer:
-      "OnePanel Pro is €4.99 per month, with unlimited access to the reader while your subscription is active. There is no free trial.",
+      "Standard mode is free, with no card or trial required. OnePanel Pro is €4.99 per month and adds GPT‑5.6 Layout for better panel detection on complex page layouts.",
   },
   {
     question: "Can I cancel my subscription any time?",
@@ -33,7 +33,7 @@ const faqs = [
   {
     question: "Do I need an account to use OnePanel Reader?",
     answer:
-      "Yes. You need to sign in and have an active OnePanel Pro subscription to create and read chapters.",
+      "No. You can create and read chapters with Standard mode without an account. Sign in and subscribe to OnePanel Pro when you want to use GPT‑5.6 Layout.",
   },
 ];
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { type NextPage } from "next";
-import { Show, SignInButton, SignUpButton, useAuth } from "../lib/auth";
+import { Show, SignInButton, useAuth } from "../lib/auth";
 import Head from "next/head";
+import Link from "next/link";
 import { useEffect } from "react";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
@@ -14,8 +15,8 @@ const audienceHighlights = [
 
 const launchProof = [
   { label: "Reader mode", value: "Panel by panel" },
-  { label: "Price", value: "€4.99/mo" },
-  { label: "Access", value: "Cancel any time" },
+  { label: "Standard", value: "Free" },
+  { label: "Pro", value: "€4.99/mo" },
 ];
 
 const softwareJsonLd = {
@@ -27,17 +28,26 @@ const softwareJsonLd = {
   url: "https://onepanel.app",
   description:
     "OnePanel Reader is a web app that reveals a manga chapter one panel at a time, so readers never see the next panel or page before they're ready for it.",
-  offers: {
-    "@type": "Offer",
-    price: "4.99",
-    priceCurrency: "EUR",
-    priceSpecification: {
-      "@type": "UnitPriceSpecification",
+  offers: [
+    {
+      "@type": "Offer",
+      name: "OnePanel Standard",
+      price: "0",
+      priceCurrency: "EUR",
+    },
+    {
+      "@type": "Offer",
+      name: "OnePanel Pro",
       price: "4.99",
       priceCurrency: "EUR",
-      unitText: "MONTH",
+      priceSpecification: {
+        "@type": "UnitPriceSpecification",
+        price: "4.99",
+        priceCurrency: "EUR",
+        unitText: "MONTH",
+      },
     },
-  },
+  ],
 };
 
 const Home: NextPage = () => {
@@ -56,7 +66,7 @@ const Home: NextPage = () => {
         <title>OnePanel Reader</title>
         <meta
           name="description"
-          content="Read manga chapters one panel at a time. OnePanel Reader turns chapter links into a focused spoiler-safe reading flow."
+          content="Read manga chapters one panel at a time for free. OnePanel Reader turns chapter links into a focused spoiler-safe reading flow, with Pro detection for complex layouts."
         />
         <meta
           property="og:title"
@@ -64,7 +74,7 @@ const Home: NextPage = () => {
         />
         <meta
           property="og:description"
-          content="Paste a manga chapter URL and read every chapter one panel at a time."
+          content="Paste a manga chapter URL and read one panel at a time for free. Upgrade only when you want Pro detection for complex layouts."
         />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://onepanel.app" />
@@ -86,7 +96,7 @@ const Home: NextPage = () => {
             <div className="container mx-auto grid gap-10 px-4 py-10 lg:grid-cols-[1.05fr_0.95fr] lg:items-center lg:py-16">
               <div>
                 <p className="mb-4 inline-flex rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-sm font-semibold text-emerald-800">
-                  New faster version available now
+                  Now free to start
                 </p>
                 <h1 className="max-w-3xl text-4xl font-black leading-tight tracking-normal text-gray-950 sm:text-5xl lg:text-6xl">
                   Manga chapters without accidental spoilers.
@@ -94,19 +104,21 @@ const Home: NextPage = () => {
                 <p className="mt-5 max-w-2xl text-lg leading-8 text-gray-700">
                   OnePanel Reader is a spoiler-free manga reader: paste an OP
                   Chapters link and it turns the chapter into a focused,
-                  panel-by-panel reading flow so every reveal lands exactly
-                  when it should.
+                  panel-by-panel reading flow so every reveal lands exactly when
+                  it should. Use Standard for free, or upgrade to Pro for better
+                  detection on complex page layouts.
                 </p>
                 <div className="mt-7 flex flex-col gap-3 sm:flex-row">
                   <Show when="signed-out">
-                    <SignUpButton>
-                      <button className="rounded-md bg-gray-950 px-5 py-3 text-base font-bold text-white hover:bg-gray-800">
-                        Start reading
-                      </button>
-                    </SignUpButton>
+                    <Link
+                      href="/reader"
+                      className="rounded-md bg-gray-950 px-5 py-3 text-center text-base font-bold text-white hover:bg-gray-800"
+                    >
+                      Start reading free
+                    </Link>
                     <SignInButton>
                       <button className="rounded-md border border-gray-300 px-5 py-3 text-base font-bold text-gray-800 hover:bg-gray-100">
-                        I already have an account
+                        Sign in
                       </button>
                     </SignInButton>
                   </Show>
@@ -170,6 +182,50 @@ const Home: NextPage = () => {
                   <p className="text-lg font-bold leading-7">{highlight}</p>
                 </div>
               ))}
+            </div>
+          </section>
+
+          <section className="border-b border-gray-200 bg-white">
+            <div className="container mx-auto px-4 py-12">
+              <div className="mx-auto max-w-3xl text-center">
+                <p className="text-sm font-bold uppercase tracking-wider text-emerald-700">
+                  Simple freemium plans
+                </p>
+                <h2 className="mt-2 text-3xl font-black text-gray-950">
+                  Read for free. Upgrade when a page gets complicated.
+                </h2>
+                <p className="mt-3 text-gray-700">
+                  No trial countdown and no card required for Standard mode.
+                </p>
+              </div>
+              <div className="mx-auto mt-8 grid max-w-3xl gap-5 md:grid-cols-2">
+                <article className="rounded-xl border border-gray-200 bg-[#f6f4ef] p-6">
+                  <p className="text-sm font-bold uppercase tracking-wider text-gray-500">
+                    Standard
+                  </p>
+                  <p className="mt-2 text-3xl font-black">Free</p>
+                  <p className="mt-3 text-gray-700">
+                    Fast panel detection for everyday page layouts. Start
+                    reading without an account.
+                  </p>
+                </article>
+                <article className="rounded-xl border-2 border-gray-950 bg-white p-6">
+                  <p className="text-sm font-bold uppercase tracking-wider text-gray-500">
+                    Pro
+                  </p>
+                  <p className="mt-2 text-3xl font-black">
+                    €4.99
+                    <span className="text-base font-semibold text-gray-500">
+                      {" "}
+                      / month
+                    </span>
+                  </p>
+                  <p className="mt-3 text-gray-700">
+                    GPT‑5.6 Layout provides better panel detection for complex
+                    page layouts. Cancel any time.
+                  </p>
+                </article>
+              </div>
             </div>
           </section>
         </main>

--- a/src/pages/spoiler-free-manga-reader.tsx
+++ b/src/pages/spoiler-free-manga-reader.tsx
@@ -1,7 +1,7 @@
 import { type NextPage } from "next";
 import Head from "next/head";
 import Link from "next/link";
-import { Show, SignInButton, SignUpButton } from "../lib/auth";
+import { Show, SignInButton } from "../lib/auth";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
 
@@ -42,7 +42,7 @@ const SpoilerFreeMangaReader: NextPage = () => {
         <title>Spoiler-Free Manga Reader | OnePanel Reader</title>
         <meta
           name="description"
-          content="OnePanel Reader is a spoiler-free manga reader that shows OP Chapters links one panel at a time, so the next reveal never shows up before you're ready."
+          content="Read OP Chapters links one panel at a time for free, so the next reveal never shows up before you're ready. Upgrade for Pro detection on complex layouts."
         />
         <meta
           property="og:title"
@@ -50,7 +50,7 @@ const SpoilerFreeMangaReader: NextPage = () => {
         />
         <meta
           property="og:description"
-          content="A panel-by-panel manga reader for OP Chapters that keeps every reveal off-screen until you get to it."
+          content="A free panel-by-panel manga reader for OP Chapters, with optional Pro detection for complex page layouts."
         />
         <meta property="og:type" content="website" />
         <meta
@@ -78,19 +78,21 @@ const SpoilerFreeMangaReader: NextPage = () => {
               <p className="mt-5 text-lg leading-8 text-gray-700">
                 OnePanel Reader is a web app that turns an OP Chapters chapter
                 link into a panel-by-panel reading flow, so you only ever see
-                one panel at a time and every reveal lands exactly when you
-                get to it.
+                one panel at a time and every reveal lands exactly when you get
+                to it. Standard panel detection is free, with no account
+                required.
               </p>
               <div className="mt-7 flex flex-col gap-3 sm:flex-row">
                 <Show when="signed-out">
-                  <SignUpButton>
-                    <button className="rounded-md bg-gray-950 px-5 py-3 text-base font-bold text-white hover:bg-gray-800">
-                      Start reading
-                    </button>
-                  </SignUpButton>
+                  <Link
+                    href="/reader"
+                    className="rounded-md bg-gray-950 px-5 py-3 text-center text-base font-bold text-white hover:bg-gray-800"
+                  >
+                    Start reading free
+                  </Link>
                   <SignInButton>
                     <button className="rounded-md border border-gray-300 px-5 py-3 text-base font-bold text-gray-800 hover:bg-gray-100">
-                      I already have an account
+                      Sign in
                     </button>
                   </SignInButton>
                 </Show>
@@ -163,9 +165,10 @@ const SpoilerFreeMangaReader: NextPage = () => {
                 </a>{" "}
                 and want every reveal to land cleanly, especially readers on
                 desktop or tablet, where a full page shows more of the next
-                panel than a phone screen does. OnePanel Pro costs
-                &euro;4.99 per month, with no free trial, and can be
-                cancelled any time. See the{" "}
+                panel than a phone screen does. Standard mode is free and works
+                without an account. For complex page layouts, OnePanel Pro adds
+                GPT‑5.6 Layout for &euro;4.99 per month and can be cancelled any
+                time. See the{" "}
                 <Link
                   href="/faq"
                   className="font-semibold text-gray-950 underline underline-offset-4 hover:text-gray-700"


### PR DESCRIPTION
## What changed

- reposition the landing page around free Standard access and optional Pro detection
- add a clear Standard versus Pro plan comparison and direct free-reader CTAs
- align the header, FAQ, spoiler-free guide, SEO/social metadata, structured offer data, and `llms.txt`
- update future campaign, social, and community copy in the marketing launch plan

## Why

The product now supports a freemium model: Standard mode is free without an account or card, while OnePanel Pro unlocks GPT-5.6 Layout for complex pages at €4.99/month. Public messaging still described the entire reader as paid and required account creation, creating an inconsistent conversion path.

## Impact

Visitors can now enter the free reader directly and understand exactly when Pro is useful. Search engines and AI summaries receive the same pricing and access model.

## Validation

- `npm run test` — 23 tests passed
- `npm run lint` — passed
- `npm run build` — passed with a schema-valid placeholder Clerk publishable key because the worktree has no local production key
- desktop and mobile landing layouts visually checked
- `npm audit` — reports 20 pre-existing high-severity transitive advisories; suggested remediation requires breaking dependency changes and is outside this PR
