### PR TITLE
Add comic file upload flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 OnePanel is a Next.js reader that reveals a manga chapter one panel at a time,
 avoiding spoilers from the rest of the page.
 
+Readers can paste a chapter URL or upload one CBZ, CBR, ZIP, RAR, or PDF file.
+They can also upload multiple page images; filenames determine page order.
+
 ## Requirements
 
 - Node.js 24 LTS
@@ -49,6 +52,8 @@ Set `NEXT_PUBLIC_GA_MEASUREMENT_ID` to a GA4 measurement ID, for example
 - `mode_selected`
 - `chapter_url_submitted`
 - `chapter_created`
+- `chapter_upload_started`
+- `chapter_upload_created`
 - `upgrade_displayed`
 - `authentication_continuation`
 - `checkout_continuation`
@@ -88,7 +93,12 @@ The browser calls the same-origin `/api/onepanel/*` rewrite, which forwards to
 
 - `POST /v2/chapter` with
   `{ "chapter_url": "...", "segmentation_mode": "standard" }`
+- `POST /v2/chapter/upload` as multipart form data with one comic container or
+  multiple page images
 - `GET /v2/chapter/:hash`
+
+Large uploads go directly to `NEXT_PUBLIC_API_URL` instead of traversing the
+Next.js rewrite, so the API must allow the frontend origin through CORS.
 
 The POST response must contain a non-empty `chapter_hash`. A chapter must contain
 at least one page; every page must contain an image URL and at least one panel

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ The browser calls the same-origin `/api/onepanel/*` rewrite, which forwards to
 - `GET /v2/chapter/:hash`
 
 Large uploads go directly to `NEXT_PUBLIC_API_URL` instead of traversing the
+Next.js proxy. Uploaded page data remains only in the current browser runtime;
+the API deletes uploaded, extracted, and normalized files after analysis and
+caches only layout JSON. Refreshing an uploaded chapter therefore requires
+re-uploading it, while identical content can reuse the cached analysis.
 Next.js rewrite, so the API must allow the frontend origin through CORS.
 
 The POST response must contain a non-empty `chapter_hash`. A chapter must contain

--- a/README.md
+++ b/README.md
@@ -98,11 +98,12 @@ The browser calls the same-origin `/api/onepanel/*` rewrite, which forwards to
 - `GET /v2/chapter/:hash`
 
 Large uploads go directly to `NEXT_PUBLIC_API_URL` instead of traversing the
-Next.js proxy. Uploaded page data remains only in the current browser runtime;
+Next.js rewrite, so the API must allow the frontend origin through CORS.
+Uploaded page data remains only in the current browser runtime;
 the API deletes uploaded, extracted, and normalized files after analysis and
 caches only layout JSON. Refreshing an uploaded chapter therefore requires
 re-uploading it, while identical content can reuse the cached analysis.
-Next.js rewrite, so the API must allow the frontend origin through CORS.
+Uploading requires a signed-in account.
 
 The POST response must contain a non-empty `chapter_hash`. A chapter must contain
 at least one page; every page must contain an image URL and at least one panel

--- a/src/components/UploadForm.jsx
+++ b/src/components/UploadForm.jsx
@@ -9,10 +9,17 @@ import {
  * @param {{
  *   childToParent: (files: File[]) => void | Promise<void>,
  *   disabled?: boolean,
+ *   locked?: boolean,
  *   progress?: number | null
  * }} props
  */
-const UploadForm = ({ childToParent, disabled = false, progress = null }) => {
+const UploadForm = ({
+  childToParent,
+  disabled = false,
+  locked = false,
+  progress = null,
+}) => {
+  const unavailable = disabled || locked;
   const inputRef = useRef(null);
   /** @type {[File[], import("react").Dispatch<import("react").SetStateAction<File[]>>]} */
   const [files, setFiles] = useState([]);
@@ -48,7 +55,7 @@ const UploadForm = ({ childToParent, disabled = false, progress = null }) => {
       <div
         onDragEnter={(event) => {
           event.preventDefault();
-          if (!disabled) setDragging(true);
+          if (!unavailable) setDragging(true);
         }}
         onDragOver={(event) => event.preventDefault()}
         onDragLeave={(event) => {
@@ -59,20 +66,20 @@ const UploadForm = ({ childToParent, disabled = false, progress = null }) => {
         onDrop={(event) => {
           event.preventDefault();
           setDragging(false);
-          if (!disabled) selectFiles(event.dataTransfer.files);
+          if (!unavailable) selectFiles(event.dataTransfer.files);
         }}
         className={`relative overflow-hidden rounded-md border-2 border-dashed px-5 py-8 text-center transition-colors ${
           isDragging
             ? "border-emerald-600 bg-emerald-50"
             : "border-gray-300 bg-[#faf9f6]"
-        } ${disabled ? "cursor-not-allowed opacity-60" : ""}`}
+        } ${unavailable ? "cursor-not-allowed opacity-60" : ""}`}
       >
         <input
           ref={inputRef}
           type="file"
           accept={CHAPTER_FILE_ACCEPT}
           multiple
-          disabled={disabled}
+          disabled={unavailable}
           onChange={(event) => selectFiles(event.target.files)}
           className="sr-only"
         />
@@ -84,7 +91,7 @@ const UploadForm = ({ childToParent, disabled = false, progress = null }) => {
         <p className="mt-2 text-sm leading-6 text-gray-600">
           One CBZ, CBR, ZIP, RAR, or PDF—or a selection of page images.
         </p>
-        {!disabled && (
+        {!unavailable && (
           <button
             type="button"
             onClick={() => inputRef.current?.click()}
@@ -121,10 +128,14 @@ const UploadForm = ({ childToParent, disabled = false, progress = null }) => {
 
       <button
         type="submit"
-        disabled={disabled || files.length === 0}
+        disabled={unavailable || files.length === 0}
         className="w-full rounded-md bg-gray-950 px-4 py-3 font-bold text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:bg-gray-400"
       >
-        {disabled ? "Preparing chapter…" : "Import chapter"}
+        {disabled
+          ? "Preparing chapter…"
+          : locked
+            ? "Sign in to import"
+            : "Import chapter"}
       </button>
     </form>
   );

--- a/src/components/UploadForm.jsx
+++ b/src/components/UploadForm.jsx
@@ -9,17 +9,18 @@ import {
  * @param {{
  *   childToParent: (files: File[]) => void | Promise<void>,
  *   disabled?: boolean,
- *   locked?: boolean,
+ *   requiresAuth?: boolean,
+ *   onAuthRequired?: () => void,
  *   progress?: number | null
  * }} props
  */
 const UploadForm = ({
   childToParent,
   disabled = false,
-  locked = false,
+  requiresAuth = false,
+  onAuthRequired,
   progress = null,
 }) => {
-  const unavailable = disabled || locked;
   const inputRef = useRef(null);
   /** @type {[File[], import("react").Dispatch<import("react").SetStateAction<File[]>>]} */
   const [files, setFiles] = useState([]);
@@ -38,6 +39,7 @@ const UploadForm = ({
     }
     setFiles(selected);
     setSelectionError(null);
+    if (requiresAuth) onAuthRequired?.();
   }
 
   function handleSubmit(event) {
@@ -45,6 +47,10 @@ const UploadForm = ({
     const validation = validateChapterFiles(files);
     if (!validation.valid) {
       setSelectionError(validation.message);
+      return;
+    }
+    if (requiresAuth) {
+      onAuthRequired?.();
       return;
     }
     void childToParent(files);
@@ -55,7 +61,7 @@ const UploadForm = ({
       <div
         onDragEnter={(event) => {
           event.preventDefault();
-          if (!unavailable) setDragging(true);
+          if (!disabled) setDragging(true);
         }}
         onDragOver={(event) => event.preventDefault()}
         onDragLeave={(event) => {
@@ -66,20 +72,20 @@ const UploadForm = ({
         onDrop={(event) => {
           event.preventDefault();
           setDragging(false);
-          if (!unavailable) selectFiles(event.dataTransfer.files);
+          if (!disabled) selectFiles(event.dataTransfer.files);
         }}
         className={`relative overflow-hidden rounded-md border-2 border-dashed px-5 py-8 text-center transition-colors ${
           isDragging
             ? "border-emerald-600 bg-emerald-50"
             : "border-gray-300 bg-[#faf9f6]"
-        } ${unavailable ? "cursor-not-allowed opacity-60" : ""}`}
+        } ${disabled ? "cursor-not-allowed opacity-60" : ""}`}
       >
         <input
           ref={inputRef}
           type="file"
           accept={CHAPTER_FILE_ACCEPT}
           multiple
-          disabled={unavailable}
+          disabled={disabled}
           onChange={(event) => selectFiles(event.target.files)}
           className="sr-only"
         />
@@ -91,7 +97,7 @@ const UploadForm = ({
         <p className="mt-2 text-sm leading-6 text-gray-600">
           One CBZ, CBR, ZIP, RAR, or PDF—or a selection of page images.
         </p>
-        {!unavailable && (
+        {!disabled && (
           <button
             type="button"
             onClick={() => inputRef.current?.click()}
@@ -128,14 +134,10 @@ const UploadForm = ({
 
       <button
         type="submit"
-        disabled={unavailable || files.length === 0}
+        disabled={disabled || files.length === 0}
         className="w-full rounded-md bg-gray-950 px-4 py-3 font-bold text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:bg-gray-400"
       >
-        {disabled
-          ? "Preparing chapter…"
-          : locked
-            ? "Sign in to import"
-            : "Import chapter"}
+        {disabled ? "Preparing chapter…" : "Import chapter"}
       </button>
     </form>
   );

--- a/src/components/UploadForm.jsx
+++ b/src/components/UploadForm.jsx
@@ -1,0 +1,133 @@
+import { useRef, useState } from "react";
+import {
+  CHAPTER_FILE_ACCEPT,
+  describeChapterFiles,
+  validateChapterFiles,
+} from "../lib/upload-selection.mjs";
+
+/**
+ * @param {{
+ *   childToParent: (files: File[]) => void | Promise<void>,
+ *   disabled?: boolean,
+ *   progress?: number | null
+ * }} props
+ */
+const UploadForm = ({ childToParent, disabled = false, progress = null }) => {
+  const inputRef = useRef(null);
+  /** @type {[File[], import("react").Dispatch<import("react").SetStateAction<File[]>>]} */
+  const [files, setFiles] = useState([]);
+  /** @type {[string | null, import("react").Dispatch<import("react").SetStateAction<string | null>>]} */
+  const [selectionError, setSelectionError] = useState(null);
+  const [isDragging, setDragging] = useState(false);
+
+  /** @param {FileList | File[]} nextFiles */
+  function selectFiles(nextFiles) {
+    const selected = Array.from(nextFiles);
+    const validation = validateChapterFiles(selected);
+    if (!validation.valid) {
+      setFiles([]);
+      setSelectionError(validation.message);
+      return;
+    }
+    setFiles(selected);
+    setSelectionError(null);
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    const validation = validateChapterFiles(files);
+    if (!validation.valid) {
+      setSelectionError(validation.message);
+      return;
+    }
+    void childToParent(files);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div
+        onDragEnter={(event) => {
+          event.preventDefault();
+          if (!disabled) setDragging(true);
+        }}
+        onDragOver={(event) => event.preventDefault()}
+        onDragLeave={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget)) {
+            setDragging(false);
+          }
+        }}
+        onDrop={(event) => {
+          event.preventDefault();
+          setDragging(false);
+          if (!disabled) selectFiles(event.dataTransfer.files);
+        }}
+        className={`relative overflow-hidden rounded-md border-2 border-dashed px-5 py-8 text-center transition-colors ${
+          isDragging
+            ? "border-emerald-600 bg-emerald-50"
+            : "border-gray-300 bg-[#faf9f6]"
+        } ${disabled ? "cursor-not-allowed opacity-60" : ""}`}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept={CHAPTER_FILE_ACCEPT}
+          multiple
+          disabled={disabled}
+          onChange={(event) => selectFiles(event.target.files)}
+          className="sr-only"
+        />
+        <p className="text-lg font-black text-gray-950">
+          {files.length > 0
+            ? describeChapterFiles(files)
+            : "Drop a comic onto the shelf"}
+        </p>
+        <p className="mt-2 text-sm leading-6 text-gray-600">
+          One CBZ, CBR, ZIP, RAR, or PDF—or a selection of page images.
+        </p>
+        {!disabled && (
+          <button
+            type="button"
+            onClick={() => inputRef.current?.click()}
+            className="mt-4 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-bold text-gray-900 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+          >
+            {files.length > 0 ? "Choose different files" : "Choose files"}
+          </button>
+        )}
+      </div>
+
+      {selectionError && (
+        <p role="alert" className="text-sm font-semibold text-red-700">
+          {selectionError}
+        </p>
+      )}
+
+      {disabled && (
+        <div aria-live="polite">
+          <div className="h-2 overflow-hidden rounded-full bg-gray-200">
+            <div
+              className={`h-full bg-emerald-600 transition-[width] ${
+                progress === null ? "w-full animate-pulse" : ""
+              }`}
+              style={progress === null ? undefined : { width: `${progress}%` }}
+            />
+          </div>
+          <p className="mt-2 text-center text-sm font-semibold text-gray-700">
+            {progress === null
+              ? "Reading pages and finding panels…"
+              : `Uploading… ${progress}%`}
+          </p>
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={disabled || files.length === 0}
+        className="w-full rounded-md bg-gray-950 px-4 py-3 font-bold text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:bg-gray-400"
+      >
+        {disabled ? "Preparing chapter…" : "Import chapter"}
+      </button>
+    </form>
+  );
+};
+
+export default UploadForm;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -82,6 +82,43 @@ export class ApiError extends Error {
   }
 }
 
+function apiErrorFromResponse(
+  status: number,
+  statusText: string,
+  responseBody: unknown,
+): ApiError {
+  const errorDetail =
+    responseBody &&
+    typeof responseBody === "object" &&
+    "detail" in responseBody
+      ? responseBody.detail
+      : responseBody;
+  const errorRecord =
+    errorDetail && typeof errorDetail === "object" ? errorDetail : null;
+  const codeResult = accessErrorCodeSchema.safeParse(
+    errorRecord && "code" in errorRecord ? errorRecord.code : undefined,
+  );
+  const message =
+    typeof errorDetail === "string"
+      ? errorDetail
+      : errorRecord &&
+          "message" in errorRecord &&
+          typeof errorRecord.message === "string"
+        ? errorRecord.message
+        : `The API returned ${status} ${statusText}.`;
+  const accessState = codeResult.success
+    ? codeResult.data === "sign_in_required"
+      ? "sign-in-required"
+      : "subscription-required"
+    : undefined;
+  return new ApiError(
+    message,
+    status,
+    codeResult.success ? codeResult.data : undefined,
+    accessState,
+  );
+}
+
 async function request(
   path: string,
   token?: string | null,
@@ -108,34 +145,7 @@ async function request(
       } catch {
         detail = null;
       }
-      const errorDetail =
-        detail && typeof detail === "object" && "detail" in detail
-          ? detail.detail
-          : detail;
-      const errorRecord =
-        errorDetail && typeof errorDetail === "object" ? errorDetail : null;
-      const codeResult = accessErrorCodeSchema.safeParse(
-        errorRecord && "code" in errorRecord ? errorRecord.code : undefined,
-      );
-      const message =
-        typeof errorDetail === "string"
-          ? errorDetail
-          : errorRecord &&
-              "message" in errorRecord &&
-              typeof errorRecord.message === "string"
-            ? errorRecord.message
-            : `The API returned ${response.status} ${response.statusText}.`;
-      const accessState = codeResult.success
-        ? codeResult.data === "sign_in_required"
-          ? "sign-in-required"
-          : "subscription-required"
-        : undefined;
-      throw new ApiError(
-        message,
-        response.status,
-        codeResult.success ? codeResult.data : undefined,
-        accessState,
-      );
+      throw apiErrorFromResponse(response.status, response.statusText, detail);
     }
 
     if (response.status === 204) return null;
@@ -188,6 +198,7 @@ export function createUploadedChapter(
   mode: SegmentationMode = DEFAULT_SEGMENTATION_MODE,
   token: string | null,
   onProgress: (progress: number | null) => void,
+  signal?: AbortSignal,
 ): Promise<UploadedChapter> {
   return new Promise((resolve, reject) => {
     const validatedMode = segmentationModeSchema.parse(mode);
@@ -200,6 +211,17 @@ export function createUploadedChapter(
     if (token) request.setRequestHeader("Authorization", `Bearer ${token}`);
     request.responseType = "json";
     request.timeout = UPLOAD_TIMEOUT_MS;
+    const abortRequest = () => request.abort();
+    signal?.addEventListener("abort", abortRequest, { once: true });
+    if (signal?.aborted) {
+      request.abort();
+      reject(new ApiError("Chapter upload was cancelled."));
+      return;
+    }
+    const settle = <T>(callback: (value: T) => void, value: T) => {
+      signal?.removeEventListener("abort", abortRequest);
+      callback(value);
+    };
 
     request.upload.onprogress = (event) => {
       if (!event.lengthComputable) return;
@@ -212,14 +234,14 @@ export function createUploadedChapter(
     };
     request.onload = () => {
       if (request.status < 200 || request.status >= 300) {
-        const detail =
-          request.response &&
-          typeof request.response === "object" &&
-          "detail" in request.response &&
-          typeof request.response.detail === "string"
-            ? request.response.detail
-            : `The API returned ${request.status} ${request.statusText}.`;
-        reject(new ApiError(detail, request.status));
+        settle(
+          reject,
+          apiErrorFromResponse(
+            request.status,
+            request.statusText,
+            request.response,
+          ),
+        );
         return;
       }
       try {
@@ -227,23 +249,30 @@ export function createUploadedChapter(
           uploadedChapterCreatedSchema,
           request.response,
         );
+        transientUploadedChapters.clear();
         transientUploadedChapters.set(result.chapter_hash, result.chapter);
-        resolve({
+        settle(resolve, {
           chapterHash: result.chapter_hash,
           chapter: result.chapter,
         });
       } catch (error) {
-        reject(error);
+        settle(reject, error);
       }
     };
     request.onerror = () =>
-      reject(
-        new ApiError("Could not reach the API while uploading the chapter."),
+      settle(
+        reject,
+        new ApiError(
+          "Could not reach the upload API. Check the API URL and CORS configuration.",
+        ),
       );
     request.ontimeout = () =>
-      reject(new ApiError("Chapter processing timed out. Please try again."));
+      settle(
+        reject,
+        new ApiError("Chapter processing timed out. Please try again."),
+      );
     request.onabort = () =>
-      reject(new ApiError("Chapter upload was cancelled."));
+      settle(reject, new ApiError("Chapter upload was cancelled."));
     request.send(formData);
   });
 }
@@ -253,7 +282,10 @@ export async function getChapter(
   token?: string | null,
 ): Promise<Chapter> {
   const transientChapter = transientUploadedChapters.get(hash);
-  if (transientChapter) return transientChapter;
+  if (transientChapter) {
+    transientUploadedChapters.delete(hash);
+    return transientChapter;
+  }
 
   const value = await request(`/v2/chapter/${encodeURIComponent(hash)}`, token);
   return parseResponse(chapterSchema, value);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -23,6 +23,10 @@ const chapterCreatedSchema = z.object({
   chapter_hash: z.string().min(1),
 });
 
+const uploadedChapterCreatedSchema = chapterCreatedSchema.extend({
+  chapter: chapterSchema,
+});
+
 const accessErrorCodeSchema = z.enum([
   "sign_in_required",
   "subscription_required",
@@ -44,6 +48,14 @@ const feedbackResponseSchema = z.union([z.object({}).passthrough(), z.null()]);
 
 export type Chapter = z.infer<typeof chapterSchema>;
 export type Subscription = z.infer<typeof subscriptionSchema>;
+export type UploadedChapter = {
+  chapterHash: string;
+  chapter: Chapter;
+};
+
+// Uploaded page bytes are deliberately kept only in this JavaScript runtime.
+// The API deletes its temporary copies after returning the analyzed chapter.
+const transientUploadedChapters = new Map<string, Chapter>();
 
 const API_TIMEOUT_MS = 120_000;
 const UPLOAD_TIMEOUT_MS = 10 * 60_000;
@@ -176,7 +188,7 @@ export function createUploadedChapter(
   mode: SegmentationMode = DEFAULT_SEGMENTATION_MODE,
   token: string | null,
   onProgress: (progress: number | null) => void,
-): Promise<string> {
+): Promise<UploadedChapter> {
   return new Promise((resolve, reject) => {
     const validatedMode = segmentationModeSchema.parse(mode);
     const formData = new FormData();
@@ -211,9 +223,15 @@ export function createUploadedChapter(
         return;
       }
       try {
-        resolve(
-          parseResponse(chapterCreatedSchema, request.response).chapter_hash,
+        const result = parseResponse(
+          uploadedChapterCreatedSchema,
+          request.response,
         );
+        transientUploadedChapters.set(result.chapter_hash, result.chapter);
+        resolve({
+          chapterHash: result.chapter_hash,
+          chapter: result.chapter,
+        });
       } catch (error) {
         reject(error);
       }
@@ -234,6 +252,9 @@ export async function getChapter(
   hash: string,
   token?: string | null,
 ): Promise<Chapter> {
+  const transientChapter = transientUploadedChapters.get(hash);
+  if (transientChapter) return transientChapter;
+
   const value = await request(`/v2/chapter/${encodeURIComponent(hash)}`, token);
   return parseResponse(chapterSchema, value);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -46,7 +46,10 @@ export type Chapter = z.infer<typeof chapterSchema>;
 export type Subscription = z.infer<typeof subscriptionSchema>;
 
 const API_TIMEOUT_MS = 120_000;
+const UPLOAD_TIMEOUT_MS = 10 * 60_000;
 const API_PROXY_PATH = "/api/onepanel";
+const UPLOAD_API_ORIGIN =
+  process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") ?? API_PROXY_PATH;
 
 export class ApiError extends Error {
   readonly status?: number;
@@ -76,18 +79,15 @@ async function request(
   const timeout = window.setTimeout(() => controller.abort(), API_TIMEOUT_MS);
 
   try {
-    const response = await fetch(
-      `${API_PROXY_PATH}${path}`,
-      {
-        ...init,
-        signal: controller.signal,
-        headers: {
-          "Content-Type": "application/json",
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-          ...init?.headers,
-        },
+    const response = await fetch(`${API_PROXY_PATH}${path}`, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...init?.headers,
       },
-    );
+    });
 
     if (!response.ok) {
       let detail: unknown;
@@ -171,20 +171,74 @@ export async function createChapter(
   return parseResponse(chapterCreatedSchema, value).chapter_hash;
 }
 
+export function createUploadedChapter(
+  files: File[],
+  mode: SegmentationMode = DEFAULT_SEGMENTATION_MODE,
+  token: string | null,
+  onProgress: (progress: number | null) => void,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const validatedMode = segmentationModeSchema.parse(mode);
+    const formData = new FormData();
+    files.forEach((file) => formData.append("files", file, file.name));
+    formData.append("segmentation_mode", validatedMode);
+
+    const request = new XMLHttpRequest();
+    request.open("POST", `${UPLOAD_API_ORIGIN}/v2/chapter/upload`);
+    if (token) request.setRequestHeader("Authorization", `Bearer ${token}`);
+    request.responseType = "json";
+    request.timeout = UPLOAD_TIMEOUT_MS;
+
+    request.upload.onprogress = (event) => {
+      if (!event.lengthComputable) return;
+      const progress = Math.min(
+        100,
+        Math.round((event.loaded / event.total) * 100),
+      );
+      onProgress(progress);
+      if (progress === 100) onProgress(null);
+    };
+    request.onload = () => {
+      if (request.status < 200 || request.status >= 300) {
+        const detail =
+          request.response &&
+          typeof request.response === "object" &&
+          "detail" in request.response &&
+          typeof request.response.detail === "string"
+            ? request.response.detail
+            : `The API returned ${request.status} ${request.statusText}.`;
+        reject(new ApiError(detail, request.status));
+        return;
+      }
+      try {
+        resolve(
+          parseResponse(chapterCreatedSchema, request.response).chapter_hash,
+        );
+      } catch (error) {
+        reject(error);
+      }
+    };
+    request.onerror = () =>
+      reject(
+        new ApiError("Could not reach the API while uploading the chapter."),
+      );
+    request.ontimeout = () =>
+      reject(new ApiError("Chapter processing timed out. Please try again."));
+    request.onabort = () =>
+      reject(new ApiError("Chapter upload was cancelled."));
+    request.send(formData);
+  });
+}
+
 export async function getChapter(
   hash: string,
   token?: string | null,
 ): Promise<Chapter> {
-  const value = await request(
-    `/v2/chapter/${encodeURIComponent(hash)}`,
-    token,
-  );
+  const value = await request(`/v2/chapter/${encodeURIComponent(hash)}`, token);
   return parseResponse(chapterSchema, value);
 }
 
-export async function getSubscription(
-  token: string,
-): Promise<Subscription> {
+export async function getSubscription(token: string): Promise<Subscription> {
   const value = await request("/v2/billing/status", token);
   return parseResponse(subscriptionSchema, value);
 }

--- a/src/lib/upload-selection.mjs
+++ b/src/lib/upload-selection.mjs
@@ -1,0 +1,59 @@
+const IMAGE_EXTENSIONS = new Set([
+  "bmp",
+  "gif",
+  "jpeg",
+  "jpg",
+  "png",
+  "tif",
+  "tiff",
+  "webp",
+]);
+const CONTAINER_EXTENSIONS = new Set(["cbz", "cbr", "zip", "rar", "pdf"]);
+
+export const CHAPTER_FILE_ACCEPT = [
+  ".cbz",
+  ".cbr",
+  ".zip",
+  ".rar",
+  ".pdf",
+  ...[...IMAGE_EXTENSIONS].map((extension) => `.${extension}`),
+].join(",");
+
+function extensionOf(filename) {
+  return filename.split(".").pop()?.toLowerCase() ?? "";
+}
+
+export function validateChapterFiles(files) {
+  if (files.length === 0) {
+    return { valid: false, message: "Choose a comic file or page images." };
+  }
+
+  const unsupported = files.find(
+    (file) =>
+      !IMAGE_EXTENSIONS.has(extensionOf(file.name)) &&
+      !CONTAINER_EXTENSIONS.has(extensionOf(file.name)),
+  );
+  if (unsupported) {
+    return {
+      valid: false,
+      message: `${unsupported.name} is not a supported comic or image format.`,
+    };
+  }
+
+  const containers = files.filter((file) =>
+    CONTAINER_EXTENSIONS.has(extensionOf(file.name)),
+  );
+  if (containers.length > 0 && files.length > 1) {
+    return {
+      valid: false,
+      message: "Choose one CBZ, CBR, ZIP, RAR, or PDF—or select page images.",
+    };
+  }
+
+  return { valid: true };
+}
+
+export function describeChapterFiles(files) {
+  if (files.length === 1) return files[0].name;
+  return `${files.length} page images`;
+}

--- a/src/pages/chapter/[hash].jsx
+++ b/src/pages/chapter/[hash].jsx
@@ -5,7 +5,7 @@ import ImageCanvas from "../../components/ImageCanvas";
 import Head from "next/head";
 import LoadingComponent from "../../components/Loading";
 import ErrorMessage from "../../components/ErrorMessage";
-import { getChapter } from "../../lib/api";
+import { ApiError, getChapter } from "../../lib/api";
 import { isChapterSignInRequired } from "../../lib/chapter-access.mjs";
 
 export default function Page() {
@@ -17,6 +17,7 @@ export default function Page() {
   const [isLoading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [requiresSignIn, setRequiresSignIn] = useState(false);
+  const [requiresReupload, setRequiresReupload] = useState(false);
   const { getToken, isLoaded, isSignedIn } = useAuth();
 
   const loadChapter = useCallback(async () => {
@@ -26,6 +27,7 @@ export default function Page() {
     setLoading(true);
     setError(null);
     setRequiresSignIn(false);
+    setRequiresReupload(false);
     setData(null);
     try {
       const token = isSignedIn ? await getToken() : null;
@@ -34,10 +36,14 @@ export default function Page() {
       setData(await getChapter(chapterHash, token));
     } catch (error) {
       const accountRequired = isChapterSignInRequired(error, isSignedIn);
+      const reuploadRequired = error instanceof ApiError && error.status === 409;
       setRequiresSignIn(accountRequired);
+      setRequiresReupload(reuploadRequired);
       setError(
         accountRequired
           ? "This GPT-5.6 chapter requires an account. Sign in to continue reading."
+          : reuploadRequired
+            ? "Uploaded chapters are session-only. Re-upload the source to read it again."
           : error instanceof Error
             ? error.message
             : "Could not load the chapter.",
@@ -66,7 +72,10 @@ export default function Page() {
         {isLoading && <LoadingComponent />}
         {error && (
           <div className="space-y-4 text-center">
-            <ErrorMessage message={error} onRetry={loadChapter} />
+            <ErrorMessage
+              message={error}
+              onRetry={requiresReupload ? undefined : loadChapter}
+            />
             {requiresSignIn && chapterHash && (
               <SignInButton
                 fallbackRedirectUrl={`/chapter/${encodeURIComponent(chapterHash)}`}
@@ -76,6 +85,15 @@ export default function Page() {
                   Sign in to read
                 </button>
               </SignInButton>
+            )}
+            {requiresReupload && (
+              <button
+                type="button"
+                onClick={() => void router.push("/reader")}
+                className="rounded-md bg-blue-600 px-4 py-2 font-semibold text-white"
+              >
+                Re-upload chapter
+              </button>
             )}
           </div>
         )}

--- a/src/pages/reader.tsx
+++ b/src/pages/reader.tsx
@@ -1,7 +1,7 @@
 import { type NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import ChapterComposer, {
   type ChapterMode,
 } from "../components/ChapterComposer";
@@ -43,6 +43,7 @@ const Reader: NextPage = () => {
   const [hasRestored, setHasRestored] = useState(false);
   const [sourceMethod, setSourceMethod] = useState<"upload" | "link">("upload");
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
+  const uploadControllerRef = useRef<AbortController | null>(null);
   const router = useRouter();
   const { getToken, isLoaded, isSignedIn } = useAuth();
 
@@ -69,6 +70,14 @@ const Reader: NextPage = () => {
   useEffect(() => {
     void loadSubscription();
   }, [loadSubscription]);
+
+  useEffect(
+    () => () => {
+      uploadControllerRef.current?.abort();
+      uploadControllerRef.current = null;
+    },
+    [],
+  );
 
   const redirectToCheckout = useCallback(
     async (chapterUrl: string, chapterMode: ChapterMode) => {
@@ -174,6 +183,13 @@ const Reader: NextPage = () => {
   }
 
   async function postFiles(files: File[]) {
+    if (!isSignedIn) {
+      setError("Sign in before uploading a comic or page images.");
+      return;
+    }
+    uploadControllerRef.current?.abort();
+    const controller = new AbortController();
+    uploadControllerRef.current = controller;
     setLoading(true);
     setUploadProgress(0);
     setError(null);
@@ -183,27 +199,35 @@ const Reader: NextPage = () => {
       source: "reader_page",
     });
     try {
-      const token = isSignedIn ? await getToken() : null;
+      const token = await getToken();
+      if (!token)
+        throw new Error("Your session expired. Please sign in again.");
       const { chapterHash } = await createUploadedChapter(
         files,
         "standard",
         token,
         setUploadProgress,
+        controller.signal,
       );
+      if (controller.signal.aborted) return;
       trackMarketingEvent("chapter_upload_created", {
         mode: "standard",
         source: "reader_page",
       });
       await router.push(`/chapter/${chapterHash}`);
     } catch (error) {
+      if (controller.signal.aborted) return;
       setError(
         error instanceof Error
           ? error.message
           : "Could not import the chapter.",
       );
     } finally {
-      setLoading(false);
-      setUploadProgress(null);
+      if (uploadControllerRef.current === controller) {
+        uploadControllerRef.current = null;
+        setLoading(false);
+        setUploadProgress(null);
+      }
     }
   }
 

--- a/src/pages/reader.tsx
+++ b/src/pages/reader.tsx
@@ -184,7 +184,7 @@ const Reader: NextPage = () => {
     });
     try {
       const token = isSignedIn ? await getToken() : null;
-      const chapterHash = await createUploadedChapter(
+      const { chapterHash } = await createUploadedChapter(
         files,
         "standard",
         token,

--- a/src/pages/reader.tsx
+++ b/src/pages/reader.tsx
@@ -10,7 +10,7 @@ import Footer from "../components/Footer";
 import Header from "../components/Header";
 import UploadForm from "../components/UploadForm";
 import UpgradeModal from "../components/UpgradeModal";
-import { useAuth } from "../lib/auth";
+import { SignInButton, useAuth } from "../lib/auth";
 import { trackMarketingEvent } from "../lib/analytics";
 import {
   createChapter,
@@ -295,9 +295,72 @@ const Reader: NextPage = () => {
               </div>
               {sourceMethod === "upload" ? (
                 <div className="p-5 sm:p-6">
+                  <aside
+                    aria-label="How uploaded files are handled"
+                    className="mb-5 overflow-hidden rounded-xl border border-emerald-200 bg-emerald-50/70"
+                  >
+                    <div className="border-b border-emerald-200 px-4 py-3">
+                      <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-800">
+                        Private by design
+                      </p>
+                      <p className="mt-1 text-sm font-semibold text-gray-950">
+                        Your comic is processed, not collected.
+                      </p>
+                    </div>
+                    <dl className="grid gap-px bg-emerald-200 sm:grid-cols-3">
+                      <div className="bg-white px-4 py-3">
+                        <dt className="text-xs font-bold text-gray-500">
+                          Before upload
+                        </dt>
+                        <dd className="mt-1 text-sm font-semibold text-gray-900">
+                          Sign in is required
+                        </dd>
+                      </div>
+                      <div className="bg-white px-4 py-3">
+                        <dt className="text-xs font-bold text-gray-500">
+                          After analysis
+                        </dt>
+                        <dd className="mt-1 text-sm font-semibold text-gray-900">
+                          Source files are deleted
+                        </dd>
+                      </div>
+                      <div className="bg-white px-4 py-3">
+                        <dt className="text-xs font-bold text-gray-500">
+                          What remains
+                        </dt>
+                        <dd className="mt-1 text-sm font-semibold text-gray-900">
+                          Panel layout JSON only
+                        </dd>
+                      </div>
+                    </dl>
+                    <p className="border-t border-emerald-200 px-4 py-3 text-xs leading-5 text-gray-700">
+                      Uploaded chapters stay available only in this browser
+                      session. Refreshing or reopening one requires the original
+                      files again.
+                    </p>
+                  </aside>
+                  {!isSignedIn && (
+                    <div className="mb-5 rounded-lg border border-gray-200 bg-gray-50 p-4 text-center">
+                      <p className="text-sm font-semibold text-gray-700">
+                        Sign in before choosing your comic files.
+                      </p>
+                      <SignInButton
+                        fallbackRedirectUrl="/reader"
+                        signUpFallbackRedirectUrl="/reader"
+                      >
+                        <button
+                          type="button"
+                          className="mt-3 rounded-md bg-gray-950 px-4 py-2 text-sm font-bold text-white hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+                        >
+                          Sign in to upload
+                        </button>
+                      </SignInButton>
+                    </div>
+                  )}
                   <UploadForm
                     childToParent={postFiles}
                     disabled={isLoading}
+                    locked={!isSignedIn}
                     progress={uploadProgress}
                   />
                 </div>

--- a/src/pages/reader.tsx
+++ b/src/pages/reader.tsx
@@ -8,12 +8,14 @@ import ChapterComposer, {
 import ErrorMessage from "../components/ErrorMessage";
 import Footer from "../components/Footer";
 import Header from "../components/Header";
+import UploadForm from "../components/UploadForm";
 import UpgradeModal from "../components/UpgradeModal";
 import { useAuth } from "../lib/auth";
 import { trackMarketingEvent } from "../lib/analytics";
 import {
   createChapter,
   createCheckout,
+  createUploadedChapter,
   getSubscription,
   type Subscription,
 } from "../lib/api";
@@ -25,7 +27,7 @@ import {
 } from "../lib/pending-chapter-request.mjs";
 
 const readerBenefits = [
-  "Paste a chapter link from your reader.",
+  "Import links, comic files, or page images.",
   "Read one panel at a time.",
   "Keep future panels off-screen.",
 ];
@@ -39,6 +41,8 @@ const Reader: NextPage = () => {
   const [mode, setMode] = useState<ChapterMode>("standard");
   const [isUpgradeOpen, setUpgradeOpen] = useState(false);
   const [hasRestored, setHasRestored] = useState(false);
+  const [sourceMethod, setSourceMethod] = useState<"upload" | "link">("upload");
+  const [uploadProgress, setUploadProgress] = useState<number | null>(null);
   const router = useRouter();
   const { getToken, isLoaded, isSignedIn } = useAuth();
 
@@ -169,13 +173,47 @@ const Reader: NextPage = () => {
     }
   }
 
+  async function postFiles(files: File[]) {
+    setLoading(true);
+    setUploadProgress(0);
+    setError(null);
+    trackMarketingEvent("chapter_upload_started", {
+      file_count: files.length,
+      mode: "standard",
+      source: "reader_page",
+    });
+    try {
+      const token = isSignedIn ? await getToken() : null;
+      const chapterHash = await createUploadedChapter(
+        files,
+        "standard",
+        token,
+        setUploadProgress,
+      );
+      trackMarketingEvent("chapter_upload_created", {
+        mode: "standard",
+        source: "reader_page",
+      });
+      await router.push(`/chapter/${chapterHash}`);
+    } catch (error) {
+      setError(
+        error instanceof Error
+          ? error.message
+          : "Could not import the chapter.",
+      );
+    } finally {
+      setLoading(false);
+      setUploadProgress(null);
+    }
+  }
+
   return (
     <>
       <Head>
         <title>Reader | OnePanel Reader</title>
         <meta
           name="description"
-          content="Paste a manga chapter URL and start a spoiler-safe panel-by-panel reading flow."
+          content="Import a comic file, page images, or a chapter URL for spoiler-safe panel-by-panel reading."
         />
         <meta name="robots" content="noindex" />
         <link rel="icon" href="/favicon.ico" />
@@ -189,30 +227,73 @@ const Reader: NextPage = () => {
                 Reader home
               </p>
               <h1 className="text-4xl font-black leading-tight tracking-normal text-gray-950 sm:text-5xl">
-                Paste a chapter link.
+                Bring your own chapter.
               </h1>
               <p className="mx-auto mt-4 max-w-2xl text-lg leading-8 text-gray-700">
-                Drop in a chapter URL from your manga reader and OnePanel will
-                open it as a focused, spoiler-safe reader.
+                Import a comic from your library, your own page scans, or a
+                chapter link. OnePanel turns it into a focused, panel-by-panel
+                reader.
               </p>
             </section>
 
             <section className="mx-auto mt-8 overflow-visible rounded-2xl border border-gray-200 bg-white shadow-lg">
-              <ChapterComposer
-                disabled={isLoading}
-                mode={mode}
-                onModeChange={(nextMode) => {
-                  setMode(nextMode);
-                  trackMarketingEvent("mode_selected", {
-                    mode: nextMode,
-                    source: "reader_page",
-                  });
-                }}
-                onSubmit={(chapterUrl) => void postUrl(chapterUrl)}
-                url={url}
-                onUrlChange={setUrl}
-              />
-              {isLoading && (
+              <div className="grid grid-cols-2 rounded-t-2xl border-b border-gray-200 bg-gray-100 p-1">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSourceMethod("upload");
+                    setError(null);
+                  }}
+                  aria-pressed={sourceMethod === "upload"}
+                  className={`rounded-xl px-3 py-2 text-sm font-bold transition-colors ${
+                    sourceMethod === "upload"
+                      ? "bg-white text-gray-950 shadow-sm"
+                      : "text-gray-600 hover:text-gray-950"
+                  }`}
+                >
+                  Upload files
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSourceMethod("link");
+                    setError(null);
+                  }}
+                  aria-pressed={sourceMethod === "link"}
+                  className={`rounded-xl px-3 py-2 text-sm font-bold transition-colors ${
+                    sourceMethod === "link"
+                      ? "bg-white text-gray-950 shadow-sm"
+                      : "text-gray-600 hover:text-gray-950"
+                  }`}
+                >
+                  Paste link
+                </button>
+              </div>
+              {sourceMethod === "upload" ? (
+                <div className="p-5 sm:p-6">
+                  <UploadForm
+                    childToParent={postFiles}
+                    disabled={isLoading}
+                    progress={uploadProgress}
+                  />
+                </div>
+              ) : (
+                <ChapterComposer
+                  disabled={isLoading}
+                  mode={mode}
+                  onModeChange={(nextMode) => {
+                    setMode(nextMode);
+                    trackMarketingEvent("mode_selected", {
+                      mode: nextMode,
+                      source: "reader_page",
+                    });
+                  }}
+                  onSubmit={(chapterUrl) => void postUrl(chapterUrl)}
+                  url={url}
+                  onUrlChange={setUrl}
+                />
+              )}
+              {isLoading && sourceMethod === "link" && (
                 <p className="border-t border-gray-100 px-5 py-3 text-center text-sm font-semibold text-gray-600">
                   Preparing your panel-by-panel reader.
                 </p>

--- a/src/pages/reader.tsx
+++ b/src/pages/reader.tsx
@@ -41,9 +41,9 @@ const Reader: NextPage = () => {
   const [mode, setMode] = useState<ChapterMode>("standard");
   const [isUpgradeOpen, setUpgradeOpen] = useState(false);
   const [hasRestored, setHasRestored] = useState(false);
-  const [sourceMethod, setSourceMethod] = useState<"upload" | "link">("upload");
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
   const uploadControllerRef = useRef<AbortController | null>(null);
+  const signInTriggerRef = useRef<HTMLButtonElement | null>(null);
   const router = useRouter();
   const { getToken, isLoaded, isSignedIn } = useAuth();
 
@@ -260,133 +260,67 @@ const Reader: NextPage = () => {
               </p>
             </section>
 
-            <section className="mx-auto mt-8 overflow-visible rounded-2xl border border-gray-200 bg-white shadow-lg">
-              <div className="grid grid-cols-2 rounded-t-2xl border-b border-gray-200 bg-gray-100 p-1">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setSourceMethod("upload");
-                    setError(null);
-                  }}
-                  aria-pressed={sourceMethod === "upload"}
-                  className={`rounded-xl px-3 py-2 text-sm font-bold transition-colors ${
-                    sourceMethod === "upload"
-                      ? "bg-white text-gray-950 shadow-sm"
-                      : "text-gray-600 hover:text-gray-950"
-                  }`}
-                >
-                  Upload files
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setSourceMethod("link");
-                    setError(null);
-                  }}
-                  aria-pressed={sourceMethod === "link"}
-                  className={`rounded-xl px-3 py-2 text-sm font-bold transition-colors ${
-                    sourceMethod === "link"
-                      ? "bg-white text-gray-950 shadow-sm"
-                      : "text-gray-600 hover:text-gray-950"
-                  }`}
-                >
-                  Paste link
-                </button>
+            <section className="mx-auto mt-8 overflow-visible rounded-2xl border border-gray-200 bg-white p-5 shadow-lg sm:p-6">
+              <div className="mb-5">
+                <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">
+                  Add a chapter
+                </p>
+                <p className="mt-1 text-sm text-gray-600">
+                  Bring the source you already have. OnePanel handles the rest.
+                </p>
               </div>
-              {sourceMethod === "upload" ? (
-                <div className="p-5 sm:p-6">
-                  <aside
-                    aria-label="How uploaded files are handled"
-                    className="mb-5 overflow-hidden rounded-xl border border-emerald-200 bg-emerald-50/70"
-                  >
-                    <div className="border-b border-emerald-200 px-4 py-3">
-                      <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-800">
-                        Private by design
-                      </p>
-                      <p className="mt-1 text-sm font-semibold text-gray-950">
-                        Your comic is processed, not collected.
-                      </p>
-                    </div>
-                    <dl className="grid gap-px bg-emerald-200 sm:grid-cols-3">
-                      <div className="bg-white px-4 py-3">
-                        <dt className="text-xs font-bold text-gray-500">
-                          Before upload
-                        </dt>
-                        <dd className="mt-1 text-sm font-semibold text-gray-900">
-                          Sign in is required
-                        </dd>
-                      </div>
-                      <div className="bg-white px-4 py-3">
-                        <dt className="text-xs font-bold text-gray-500">
-                          After analysis
-                        </dt>
-                        <dd className="mt-1 text-sm font-semibold text-gray-900">
-                          Source files are deleted
-                        </dd>
-                      </div>
-                      <div className="bg-white px-4 py-3">
-                        <dt className="text-xs font-bold text-gray-500">
-                          What remains
-                        </dt>
-                        <dd className="mt-1 text-sm font-semibold text-gray-900">
-                          Panel layout JSON only
-                        </dd>
-                      </div>
-                    </dl>
-                    <p className="border-t border-emerald-200 px-4 py-3 text-xs leading-5 text-gray-700">
-                      Uploaded chapters stay available only in this browser
-                      session. Refreshing or reopening one requires the original
-                      files again.
-                    </p>
-                  </aside>
-                  {!isSignedIn && (
-                    <div className="mb-5 rounded-lg border border-gray-200 bg-gray-50 p-4 text-center">
-                      <p className="text-sm font-semibold text-gray-700">
-                        Sign in before choosing your comic files.
-                      </p>
-                      <SignInButton
-                        fallbackRedirectUrl="/reader"
-                        signUpFallbackRedirectUrl="/reader"
-                      >
-                        <button
-                          type="button"
-                          className="mt-3 rounded-md bg-gray-950 px-4 py-2 text-sm font-bold text-white hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
-                        >
-                          Sign in to upload
-                        </button>
-                      </SignInButton>
-                    </div>
-                  )}
+              <div className="space-y-5">
+                <div>
                   <UploadForm
                     childToParent={postFiles}
                     disabled={isLoading}
-                    locked={!isSignedIn}
+                    requiresAuth={!isSignedIn}
+                    onAuthRequired={() => signInTriggerRef.current?.click()}
                     progress={uploadProgress}
                   />
                 </div>
-              ) : (
-                <ChapterComposer
-                  disabled={isLoading}
-                  mode={mode}
-                  onModeChange={(nextMode) => {
-                    setMode(nextMode);
-                    trackMarketingEvent("mode_selected", {
-                      mode: nextMode,
-                      source: "reader_page",
-                    });
-                  }}
-                  onSubmit={(chapterUrl) => void postUrl(chapterUrl)}
-                  url={url}
-                  onUrlChange={setUrl}
-                />
-              )}
-              {isLoading && sourceMethod === "link" && (
-                <p className="border-t border-gray-100 px-5 py-3 text-center text-sm font-semibold text-gray-600">
+                <div className="flex items-center gap-3" aria-hidden="true">
+                  <span className="h-px flex-1 bg-gray-200" />
+                  <span className="text-xs font-bold uppercase tracking-[0.14em] text-gray-400">
+                    or paste a link
+                  </span>
+                  <span className="h-px flex-1 bg-gray-200" />
+                </div>
+                <div className="overflow-visible rounded-xl border border-gray-200 bg-[#faf9f6]">
+                  <ChapterComposer
+                    disabled={isLoading}
+                    mode={mode}
+                    onModeChange={(nextMode) => {
+                      setMode(nextMode);
+                      trackMarketingEvent("mode_selected", {
+                        mode: nextMode,
+                        source: "reader_page",
+                      });
+                    }}
+                    onSubmit={(chapterUrl) => void postUrl(chapterUrl)}
+                    url={url}
+                    onUrlChange={setUrl}
+                  />
+                </div>
+              </div>
+              <aside
+                aria-label="How uploaded files are handled"
+                className="mt-5 rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-950"
+              >
+                <p className="font-bold">Private by design</p>
+                <p className="mt-1 leading-6 text-emerald-900/80">
+                  File uploads are deleted after analysis. Only panel layout
+                  JSON remains, and you will need the original files again
+                  after this browser session.
+                </p>
+              </aside>
+              {isLoading && uploadProgress === null && (
+                <p className="pt-4 text-center text-sm font-semibold text-gray-600">
                   Preparing your panel-by-panel reader.
                 </p>
               )}
               {error && (
-                <div className="px-5 pb-5">
+                <div className="pt-5">
                   <ErrorMessage message={error} />
                 </div>
               )}
@@ -406,6 +340,22 @@ const Reader: NextPage = () => {
         </main>
         <Footer />
       </div>
+      {!isSignedIn && (
+        <SignInButton
+          mode="modal"
+          fallbackRedirectUrl="/reader"
+          signUpFallbackRedirectUrl="/reader"
+        >
+          <button
+            ref={signInTriggerRef}
+            type="button"
+            className="sr-only"
+            tabIndex={-1}
+          >
+            Sign in to upload
+          </button>
+        </SignInButton>
+      )}
       {isUpgradeOpen && (
         <UpgradeModal
           isSignedIn={isSignedIn}

--- a/test/api.test.mjs
+++ b/test/api.test.mjs
@@ -1,13 +1,20 @@
 import assert from "node:assert/strict";
 import test, { afterEach } from "node:test";
-import { ApiError, createChapter, getChapter } from "../src/lib/api.ts";
+import {
+  ApiError,
+  createChapter,
+  createUploadedChapter,
+  getChapter,
+} from "../src/lib/api.ts";
 
 globalThis.window = globalThis;
 
 const originalFetch = globalThis.fetch;
+const originalXMLHttpRequest = globalThis.XMLHttpRequest;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  globalThis.XMLHttpRequest = originalXMLHttpRequest;
 });
 
 function jsonResponse(value, init = {}) {
@@ -81,4 +88,116 @@ test("billing calls remain token-required at the type boundary", async () => {
 
   const { getSubscription } = await import("../src/lib/api.ts");
   await getSubscription("billing-token");
+});
+
+class FakeXMLHttpRequest {
+  static latest;
+
+  upload = {};
+  response = null;
+  status = 0;
+  statusText = "";
+  headers = new Map();
+
+  constructor() {
+    FakeXMLHttpRequest.latest = this;
+  }
+
+  open(method, url) {
+    this.method = method;
+    this.url = url;
+  }
+
+  setRequestHeader(name, value) {
+    this.headers.set(name, value);
+  }
+
+  send(body) {
+    this.body = body;
+  }
+
+  abort() {
+    this.onabort?.();
+  }
+}
+
+test("upload errors preserve structured access details", async () => {
+  globalThis.XMLHttpRequest = FakeXMLHttpRequest;
+  const pending = createUploadedChapter(
+    [new File(["page"], "page.png")],
+    "standard",
+    null,
+    () => {},
+  );
+  const request = FakeXMLHttpRequest.latest;
+  request.status = 401;
+  request.statusText = "Unauthorized";
+  request.response = {
+    detail: {
+      code: "sign_in_required",
+      message: "Sign in before uploading.",
+    },
+  };
+  request.onload();
+
+  await assert.rejects(pending, (error) => {
+    assert.ok(error instanceof ApiError);
+    assert.equal(error.code, "sign_in_required");
+    assert.equal(error.accessState, "sign-in-required");
+    assert.equal(error.message, "Sign in before uploading.");
+    return true;
+  });
+});
+
+test("uploaded chapters are consumed once from transient memory", async () => {
+  globalThis.XMLHttpRequest = FakeXMLHttpRequest;
+  const chapter = {
+    pages: [{ image: "data:image/webp;base64,AA==", panels: [{ path: "0 0" }] }],
+  };
+  const pending = createUploadedChapter(
+    [new File(["page"], "page.png")],
+    "standard",
+    "token",
+    () => {},
+  );
+  const request = FakeXMLHttpRequest.latest;
+  request.status = 200;
+  request.response = { chapter_hash: "transient-upload", chapter };
+  request.onload();
+  await pending;
+
+  globalThis.fetch = async () => {
+    throw new Error("the first read must not call the API");
+  };
+  assert.deepEqual(await getChapter("transient-upload", "token"), chapter);
+
+  globalThis.fetch = async () =>
+    jsonResponse(
+      { detail: "Uploaded chapters are session-only." },
+      { status: 409, statusText: "Conflict" },
+    );
+  await assert.rejects(
+    getChapter("transient-upload", "token"),
+    (error) => error instanceof ApiError && error.status === 409,
+  );
+});
+
+test("aborting an upload aborts its XHR", async () => {
+  globalThis.XMLHttpRequest = FakeXMLHttpRequest;
+  const controller = new AbortController();
+  const pending = createUploadedChapter(
+    [new File(["page"], "page.png")],
+    "standard",
+    "token",
+    () => {},
+    controller.signal,
+  );
+
+  controller.abort();
+
+  await assert.rejects(
+    pending,
+    (error) =>
+      error instanceof ApiError && error.message === "Chapter upload was cancelled.",
+  );
 });

--- a/test/upload-selection.test.mjs
+++ b/test/upload-selection.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  describeChapterFiles,
+  validateChapterFiles,
+} from "../src/lib/upload-selection.mjs";
+
+const named = (name) => ({ name });
+
+test("accepts one comic container or PDF", () => {
+  for (const extension of ["cbz", "cbr", "zip", "rar", "pdf"]) {
+    assert.deepEqual(validateChapterFiles([named(`chapter.${extension}`)]), {
+      valid: true,
+    });
+  }
+});
+
+test("accepts multiple page images", () => {
+  assert.deepEqual(
+    validateChapterFiles([named("1.jpg"), named("2.PNG"), named("3.webp")]),
+    { valid: true },
+  );
+  assert.equal(
+    describeChapterFiles([named("1.jpg"), named("2.png")]),
+    "2 page images",
+  );
+});
+
+test("rejects mixed containers and files", () => {
+  assert.deepEqual(
+    validateChapterFiles([named("chapter.cbz"), named("cover.png")]),
+    {
+      valid: false,
+      message: "Choose one CBZ, CBR, ZIP, RAR, or PDF—or select page images.",
+    },
+  );
+});
+
+test("rejects unsupported files", () => {
+  assert.deepEqual(validateChapterFiles([named("chapter.epub")]), {
+    valid: false,
+    message: "chapter.epub is not a supported comic or image format.",
+  });
+});


### PR DESCRIPTION
## What changed

- Adds an upload-first chapter composer for CBZ, CBR, ZIP, RAR, PDF, and page images.
- Requires sign-in for uploads and preserves structured API access errors.
- Uploads directly to NEXT_PUBLIC_API_URL with progress, timeout, CORS guidance, and abort-on-unmount behavior.
- Keeps returned uploaded pages in a single transient entry, consumes it on first chapter read, and provides a re-upload recovery action after refresh.
- Preserves existing Standard and GPT-5.6 URL ingestion behavior.

## Dependency

Deploy Manga-Panel-Extractor #12 before this frontend PR.

## Validation

- npm run test — 30 tests passed.
- npm run lint.
- NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=test SKIP_ENV_VALIDATION=1 npm run build.
- npm audit — reports 20 existing high-severity transitive findings; suggested automatic fixes are breaking changes.
- Local Claude Sonnet re-review found no remaining actionable defects.
- Diff whitespace checks passed.