### PR TITLE
Update blog content for comic uploads

### DIFF
--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -16,9 +16,14 @@ const faqs = [
       "Instead of showing a full scanned page with several panels at once, OnePanel splits the chapter into individual panels in reading order and shows only the current one. You move forward and back with the left and right arrow keys.",
   },
   {
-    question: "Which manga sites does OnePanel Reader work with?",
+    question: "Which chapter sources does OnePanel Reader support?",
     answer:
-      "OnePanel Reader currently accepts chapter links from opchapters.com only. Paste a chapter URL from that site to start reading.",
+      "You can upload one CBZ, CBR, ZIP, RAR, or PDF comic, select multiple JPG, JPEG, PNG, or WebP page images, or paste a chapter URL from opchapters.com. Multiple images are ordered by filename.",
+  },
+  {
+    question: "What happens to uploaded files?",
+    answer:
+      "Uploaded files are deleted after analysis. OnePanel keeps only the panel layout data, and you will need your original files again after the current browser session ends.",
   },
   {
     question: "How much does OnePanel Reader cost?",
@@ -33,7 +38,7 @@ const faqs = [
   {
     question: "Do I need an account to use OnePanel Reader?",
     answer:
-      "No. You can create and read chapters with Standard mode without an account. Sign in and subscribe to OnePanel Pro when you want to use GPT‑5.6 Layout.",
+      "You can paste a supported chapter link and use Standard mode without an account. File uploads require sign-in. Subscribe to OnePanel Pro when you want GPT‑5.6 Layout.",
   },
 ];
 
@@ -43,81 +48,90 @@ const faqJsonLd = {
   mainEntity: faqs.map((faq) => ({
     "@type": "Question",
     name: faq.question,
-    acceptedAnswer: {
-      "@type": "Answer",
-      text: faq.answer,
-    },
+    acceptedAnswer: { "@type": "Answer", text: faq.answer },
   })),
 };
 
-const Faq: NextPage = () => {
-  return (
-    <>
-      <Head>
-        <title>FAQ | OnePanel Reader</title>
-        <meta
-          name="description"
-          content="Answers to common questions about OnePanel Reader: pricing, supported manga sources, cancellation, and how the spoiler-free panel-by-panel reader works."
-        />
-        <meta property="og:title" content="FAQ | OnePanel Reader" />
-        <meta
-          property="og:description"
-          content="Common questions about OnePanel Reader's pricing, supported sources, and spoiler-free reading flow."
-        />
-        <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://onepanel.app/faq" />
-        <meta property="og:image" content="https://onepanel.app/og-image.jpg" />
-        <meta property="og:image:width" content="1200" />
-        <meta property="og:image:height" content="630" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <link rel="canonical" href="https://onepanel.app/faq" />
-        <link rel="icon" href="/favicon.ico" />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-        />
-      </Head>
-      <div className="flex min-h-screen flex-col bg-[#f6f4ef] text-gray-950">
-        <Header />
-        <main className="flex-grow">
-          <section className="border-b border-gray-200 bg-white">
-            <div className="container mx-auto max-w-3xl px-4 py-12">
-              <h1 className="text-4xl font-black leading-tight tracking-normal text-gray-950 sm:text-5xl">
-                Frequently asked questions
-              </h1>
-              <p className="mt-5 text-lg leading-8 text-gray-700">
-                Everything you need to know about reading manga with OnePanel
-                Reader. Still stuck? See the{" "}
-                <Link
-                  href="/spoiler-free-manga-reader"
-                  className="font-semibold text-gray-950 underline underline-offset-4 hover:text-gray-700"
-                >
-                  spoiler-free reading guide
-                </Link>
-                .
+const Faq: NextPage = () => (
+  <>
+    <Head>
+      <title>FAQ | OnePanel Reader</title>
+      <meta
+        name="description"
+        content="Answers about OnePanel Reader pricing, supported comic uploads and chapter links, file privacy, and spoiler-free panel-by-panel reading."
+      />
+      <meta property="og:title" content="FAQ | OnePanel Reader" />
+      <meta
+        property="og:description"
+        content="Common questions about comic uploads, supported chapter sources, pricing, privacy, and spoiler-free reading."
+      />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="https://onepanel.app/faq" />
+      <meta property="og:image" content="https://onepanel.app/og-image.jpg" />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <link rel="canonical" href="https://onepanel.app/faq" />
+      <link rel="icon" href="/favicon.ico" />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+    </Head>
+    <div className="flex min-h-screen flex-col bg-[#f6f4ef] text-gray-950">
+      <Header />
+      <main className="flex-grow">
+        <section className="border-b border-gray-200 bg-white">
+          <div className="container mx-auto max-w-3xl px-4 py-12">
+            <h1 className="text-4xl font-black leading-tight tracking-normal text-gray-950 sm:text-5xl">
+              Frequently asked questions
+            </h1>
+            <p className="mt-5 text-lg leading-8 text-gray-700">
+              Everything you need to know about bringing a chapter to OnePanel
+              Reader. Still stuck? See the{" "}
+              <Link
+                href="/spoiler-free-manga-reader"
+                className="font-semibold text-gray-950 underline underline-offset-4 hover:text-gray-700"
+              >
+                spoiler-free reading guide
+              </Link>
+              .
+            </p>
+          </div>
+        </section>
+        <section>
+          <div className="container mx-auto max-w-3xl px-4 py-12">
+            <dl className="space-y-8">
+              {faqs.map((faq) => (
+                <div key={faq.question}>
+                  <dt className="text-lg font-bold text-gray-950">
+                    {faq.question}
+                  </dt>
+                  <dd className="mt-2 text-gray-700">{faq.answer}</dd>
+                </div>
+              ))}
+            </dl>
+            <div className="mt-12 rounded-xl bg-white p-8 text-center shadow-sm ring-1 ring-gray-200">
+              <h2 className="text-2xl font-black text-gray-950">
+                Have a chapter ready?
+              </h2>
+              <p className="mt-2 text-gray-700">
+                Upload your comic or paste a supported link and read one panel
+                at a time.
               </p>
+              <Link
+                href="/reader"
+                className="mt-5 inline-block rounded-md bg-gray-950 px-5 py-3 text-base font-bold text-white hover:bg-gray-800"
+              >
+                Start reading free
+              </Link>
             </div>
-          </section>
-
-          <section>
-            <div className="container mx-auto max-w-3xl px-4 py-12">
-              <dl className="space-y-8">
-                {faqs.map((faq) => (
-                  <div key={faq.question}>
-                    <dt className="text-lg font-bold text-gray-950">
-                      {faq.question}
-                    </dt>
-                    <dd className="mt-2 text-gray-700">{faq.answer}</dd>
-                  </div>
-                ))}
-              </dl>
-            </div>
-          </section>
-        </main>
-        <Footer />
-      </div>
-    </>
-  );
-};
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  </>
+);
 
 export default Faq;

--- a/src/pages/spoiler-free-manga-reader.tsx
+++ b/src/pages/spoiler-free-manga-reader.tsx
@@ -146,6 +146,24 @@ const SpoilerFreeMangaReader: NextPage = () => (
                 </li>
               ))}
             </ol>
+            <div className="mx-auto mt-10 max-w-xl overflow-hidden rounded-md border border-gray-200 bg-[#111111] shadow-2xl">
+              <div className="flex items-center gap-2 border-b border-white/10 bg-black px-4 py-3">
+                <span className="h-3 w-3 rounded-full bg-red-400" />
+                <span className="h-3 w-3 rounded-full bg-yellow-300" />
+                <span className="h-3 w-3 rounded-full bg-emerald-400" />
+                <span className="ml-3 text-xs font-semibold text-gray-300">
+                  OnePanel Reader
+                </span>
+              </div>
+              <div className="flex justify-center p-6">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src="/preview.gif"
+                  alt="OnePanel Reader moving through a manga chapter one panel at a time"
+                  className="w-full max-w-[280px]"
+                />
+              </div>
+            </div>
           </div>
         </section>
 

--- a/src/pages/spoiler-free-manga-reader.tsx
+++ b/src/pages/spoiler-free-manga-reader.tsx
@@ -22,8 +22,8 @@ const spoilerCauses = [
 
 const steps = [
   {
-    title: "Paste an OP Chapters link",
-    body: "Copy a chapter URL from opchapters.com and paste it into OnePanel Reader.",
+    title: "Bring your own chapter",
+    body: "Upload a CBZ, CBR, ZIP, RAR, or PDF comic, select multiple page images, or paste an OP Chapters link.",
   },
   {
     title: "OnePanel builds a panel-by-panel flow",
@@ -35,155 +35,166 @@ const steps = [
   },
 ];
 
-const SpoilerFreeMangaReader: NextPage = () => {
-  return (
-    <>
-      <Head>
-        <title>Spoiler-Free Manga Reader | OnePanel Reader</title>
-        <meta
-          name="description"
-          content="Read OP Chapters links one panel at a time for free, so the next reveal never shows up before you're ready. Upgrade for Pro detection on complex layouts."
-        />
-        <meta
-          property="og:title"
-          content="Spoiler-Free Manga Reader | OnePanel Reader"
-        />
-        <meta
-          property="og:description"
-          content="A free panel-by-panel manga reader for OP Chapters, with optional Pro detection for complex page layouts."
-        />
-        <meta property="og:type" content="website" />
-        <meta
-          property="og:url"
-          content="https://onepanel.app/spoiler-free-manga-reader"
-        />
-        <meta property="og:image" content="https://onepanel.app/og-image.jpg" />
-        <meta property="og:image:width" content="1200" />
-        <meta property="og:image:height" content="630" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <link
-          rel="canonical"
-          href="https://onepanel.app/spoiler-free-manga-reader"
-        />
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
-      <div className="flex min-h-screen flex-col bg-[#f6f4ef] text-gray-950">
-        <Header />
-        <main className="flex-grow">
-          <section className="border-b border-gray-200 bg-white">
-            <div className="container mx-auto max-w-3xl px-4 py-12">
-              <h1 className="text-4xl font-black leading-tight tracking-normal text-gray-950 sm:text-5xl">
-                A spoiler-free manga reader for OP Chapters
-              </h1>
-              <p className="mt-5 text-lg leading-8 text-gray-700">
-                OnePanel Reader is a web app that turns an OP Chapters chapter
-                link into a panel-by-panel reading flow, so you only ever see
-                one panel at a time and every reveal lands exactly when you get
-                to it. Standard panel detection is free, with no account
-                required.
-              </p>
-              <div className="mt-7 flex flex-col gap-3 sm:flex-row">
-                <Show when="signed-out">
-                  <Link
-                    href="/reader"
-                    className="rounded-md bg-gray-950 px-5 py-3 text-center text-base font-bold text-white hover:bg-gray-800"
-                  >
-                    Start reading free
-                  </Link>
-                  <SignInButton>
-                    <button className="rounded-md border border-gray-300 px-5 py-3 text-base font-bold text-gray-800 hover:bg-gray-100">
-                      Sign in
-                    </button>
-                  </SignInButton>
-                </Show>
-                <Show when="signed-in">
-                  <Link
-                    href="/reader"
-                    className="rounded-md bg-gray-950 px-5 py-3 text-center text-base font-bold text-white hover:bg-gray-800"
-                  >
-                    Open reader
-                  </Link>
-                </Show>
-              </div>
-            </div>
-          </section>
+const ReaderCta = () => (
+  <div className="mt-7 flex flex-col justify-center gap-3 sm:flex-row">
+    <Show when="signed-out">
+      <Link
+        href="/reader"
+        className="rounded-md bg-gray-950 px-5 py-3 text-center text-base font-bold text-white hover:bg-gray-800"
+      >
+        Start reading free
+      </Link>
+      <SignInButton>
+        <button className="rounded-md border border-gray-300 px-5 py-3 text-base font-bold text-gray-800 hover:bg-gray-100">
+          Sign in
+        </button>
+      </SignInButton>
+    </Show>
+    <Show when="signed-in">
+      <Link
+        href="/reader"
+        className="rounded-md bg-gray-950 px-5 py-3 text-center text-base font-bold text-white hover:bg-gray-800"
+      >
+        Open reader
+      </Link>
+    </Show>
+  </div>
+);
 
-          <section className="border-b border-gray-200">
-            <div className="container mx-auto max-w-3xl px-4 py-12">
-              <h2 className="text-2xl font-black text-gray-950 sm:text-3xl">
-                Why manga scans spoil themselves
-              </h2>
-              <div className="mt-6 space-y-6">
-                {spoilerCauses.map((cause) => (
-                  <div
-                    key={cause.title}
-                    className="border-l-4 border-gray-950 pl-4"
-                  >
-                    <h3 className="text-lg font-bold">{cause.title}</h3>
-                    <p className="mt-1 text-gray-700">{cause.body}</p>
+const SpoilerFreeMangaReader: NextPage = () => (
+  <>
+    <Head>
+      <title>Spoiler-Free Manga Reader | OnePanel Reader</title>
+      <meta
+        name="description"
+        content="Turn your comic files, page images, or OP Chapters links into a spoiler-free panel-by-panel manga reader. Standard detection is free."
+      />
+      <meta
+        property="og:title"
+        content="Spoiler-Free Manga Reader | OnePanel Reader"
+      />
+      <meta
+        property="og:description"
+        content="Upload a comic or paste a chapter link, then read it one panel at a time without seeing the next reveal early."
+      />
+      <meta property="og:type" content="website" />
+      <meta
+        property="og:url"
+        content="https://onepanel.app/spoiler-free-manga-reader"
+      />
+      <meta property="og:image" content="https://onepanel.app/og-image.jpg" />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <link
+        rel="canonical"
+        href="https://onepanel.app/spoiler-free-manga-reader"
+      />
+      <link rel="icon" href="/favicon.ico" />
+    </Head>
+    <div className="flex min-h-screen flex-col bg-[#f6f4ef] text-gray-950">
+      <Header />
+      <main className="flex-grow">
+        <section className="border-b border-gray-200 bg-white">
+          <div className="container mx-auto max-w-3xl px-4 py-12">
+            <h1 className="text-4xl font-black leading-tight tracking-normal text-gray-950 sm:text-5xl">
+              A spoiler-free manga reader for your own chapters
+            </h1>
+            <p className="mt-5 text-lg leading-8 text-gray-700">
+              OnePanel Reader turns comic files, page images, and OP Chapters
+              links into a panel-by-panel reading flow, so every reveal lands
+              exactly when you get to it. Standard panel detection is free.
+            </p>
+            <ReaderCta />
+          </div>
+        </section>
+
+        <section className="border-b border-gray-200">
+          <div className="container mx-auto max-w-3xl px-4 py-12">
+            <h2 className="text-2xl font-black text-gray-950 sm:text-3xl">
+              Why manga scans spoil themselves
+            </h2>
+            <div className="mt-6 space-y-6">
+              {spoilerCauses.map((cause) => (
+                <div
+                  key={cause.title}
+                  className="border-l-4 border-gray-950 pl-4"
+                >
+                  <h3 className="text-lg font-bold">{cause.title}</h3>
+                  <p className="mt-1 text-gray-700">{cause.body}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="border-b border-gray-200 bg-white">
+          <div className="container mx-auto max-w-3xl px-4 py-12">
+            <h2 className="text-2xl font-black text-gray-950 sm:text-3xl">
+              How OnePanel Reader fixes it
+            </h2>
+            <ol className="mt-6 space-y-6">
+              {steps.map((step, index) => (
+                <li key={step.title} className="flex gap-4">
+                  <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-gray-950 text-sm font-bold text-white">
+                    {index + 1}
+                  </span>
+                  <div>
+                    <h3 className="text-lg font-bold">{step.title}</h3>
+                    <p className="mt-1 text-gray-700">{step.body}</p>
                   </div>
-                ))}
-              </div>
-            </div>
-          </section>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
 
-          <section className="border-b border-gray-200 bg-white">
-            <div className="container mx-auto max-w-3xl px-4 py-12">
-              <h2 className="text-2xl font-black text-gray-950 sm:text-3xl">
-                How OnePanel Reader fixes it
-              </h2>
-              <ol className="mt-6 space-y-6">
-                {steps.map((step, index) => (
-                  <li key={step.title} className="flex gap-4">
-                    <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-gray-950 text-sm font-bold text-white">
-                      {index + 1}
-                    </span>
-                    <div>
-                      <h3 className="text-lg font-bold">{step.title}</h3>
-                      <p className="mt-1 text-gray-700">{step.body}</p>
-                    </div>
-                  </li>
-                ))}
-              </ol>
-            </div>
-          </section>
+        <section className="border-b border-gray-200">
+          <div className="container mx-auto max-w-3xl px-4 py-12">
+            <h2 className="text-2xl font-black text-gray-950 sm:text-3xl">
+              Read from the source you already have
+            </h2>
+            <p className="mt-4 text-gray-700">
+              Import a comic archive or PDF, choose page images from your
+              device, or paste a chapter URL from{" "}
+              <a
+                href="https://opchapters.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-gray-950 underline underline-offset-4 hover:text-gray-700"
+              >
+                OP Chapters
+              </a>
+              . Uploaded files require an account and are deleted after
+              analysis; only the panel layout remains for the current browser
+              session. Standard mode is free, while OnePanel Pro adds GPT‑5.6
+              Layout for complex pages. See the{" "}
+              <Link
+                href="/faq"
+                className="font-semibold text-gray-950 underline underline-offset-4 hover:text-gray-700"
+              >
+                FAQ
+              </Link>{" "}
+              for details.
+            </p>
+          </div>
+        </section>
 
-          <section>
-            <div className="container mx-auto max-w-3xl px-4 py-12">
-              <h2 className="text-2xl font-black text-gray-950 sm:text-3xl">
-                Who OnePanel Reader is for
-              </h2>
-              <p className="mt-4 text-gray-700">
-                OnePanel Reader is built for people who read manga on{" "}
-                <a
-                  href="https://opchapters.com/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-semibold text-gray-950 underline underline-offset-4 hover:text-gray-700"
-                >
-                  OP Chapters
-                </a>{" "}
-                and want every reveal to land cleanly, especially readers on
-                desktop or tablet, where a full page shows more of the next
-                panel than a phone screen does. Standard mode is free and works
-                without an account. For complex page layouts, OnePanel Pro adds
-                GPT‑5.6 Layout for &euro;4.99 per month and can be cancelled any
-                time. See the{" "}
-                <Link
-                  href="/faq"
-                  className="font-semibold text-gray-950 underline underline-offset-4 hover:text-gray-700"
-                >
-                  FAQ
-                </Link>{" "}
-                for details on pricing and supported sources.
-              </p>
-            </div>
-          </section>
-        </main>
-        <Footer />
-      </div>
-    </>
-  );
-};
+        <section className="bg-white">
+          <div className="container mx-auto max-w-3xl px-4 py-12 text-center">
+            <h2 className="text-2xl font-black text-gray-950 sm:text-3xl">
+              Ready to keep the next reveal off-screen?
+            </h2>
+            <p className="mx-auto mt-3 max-w-2xl text-gray-700">
+              Bring a chapter and start reading it one panel at a time.
+            </p>
+            <ReaderCta />
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  </>
+);
 
 export default SpoilerFreeMangaReader;


### PR DESCRIPTION
## What changed

- Update the spoiler-free manga reader guide to cover comic archives, PDFs, page images, and OP Chapters links.
- Explain upload sign-in and ephemeral file handling.
- Add a dedicated end-of-page reader CTA.
- Update the FAQ, structured data, and SEO metadata for the new source options.

## Why

The editorial pages still described OnePanel as an OP Chapters-only reader after comic-file and page-image uploads launched.

## Validation

- `npm run test` — 30 tests passed
- `npm run lint` — passed
- `npm run build` — passed
- `npm audit` — reports 20 existing high-severity transitive dependency advisories; no dependency changes are included in this PR.