### PR TITLE
Support TCB chapter links and source requests

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -12,7 +12,7 @@ arrow-key navigation.
 
 ## Key facts
 
-- OnePanel Reader works with chapter links from https://opchapters.com/.
+- OnePanel Reader works with chapter links from https://opchapters.com/ and https://tcbonepiecechapters.com/.
 - Pricing: Standard mode is free with no account or card required. OnePanel
   Pro is EUR 4.99 per month, adds GPT-5.6 Layout for complex pages, and can be
   cancelled any time. Billing is handled by Stripe.

--- a/src/components/ChapterComposer.tsx
+++ b/src/components/ChapterComposer.tsx
@@ -64,7 +64,7 @@ export default function ChapterComposer({
         disabled={disabled}
         value={url}
         onChange={(event) => onUrlChange(event.target.value)}
-        placeholder="Paste an OP Chapters link…"
+        placeholder="Paste an OP Chapters or TCB chapter link…"
         className="block w-full resize-none border-0 bg-transparent px-5 pt-5 text-lg text-gray-950 placeholder:text-gray-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed disabled:text-gray-500"
       />
       <div className="flex items-end justify-between gap-3 border-t border-gray-200 px-4 py-3">

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -26,6 +26,14 @@ const Footer = () => {
           >
             Find OP Chapters
           </a>
+          <a
+            href="https://tcbonepiecechapters.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-semibold text-gray-800 underline underline-offset-4 hover:text-gray-950"
+          >
+            Find TCB Chapters
+          </a>
         </div>
       </div>
     </footer>

--- a/src/components/SourceRequestForm.tsx
+++ b/src/components/SourceRequestForm.tsx
@@ -1,0 +1,90 @@
+import { useState, type FormEvent } from "react";
+import { createSourceRequestMailto } from "../lib/source-request.mjs";
+
+export default function SourceRequestForm() {
+  const [sourceUrl, setSourceUrl] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const mailto = createSourceRequestMailto(sourceUrl);
+    if (!mailto) {
+      setStatus(null);
+      setError("Enter a valid website or chapter URL.");
+      return;
+    }
+
+    setError(null);
+    setStatus("Your email app should open with the request ready to send.");
+    window.location.href = mailto;
+  }
+
+  return (
+    <section
+      aria-labelledby="source-request-title"
+      className="mx-auto mt-6 rounded-2xl border border-dashed border-gray-300 bg-white/60 p-5 sm:p-6"
+    >
+      <div className="grid gap-5 sm:grid-cols-[minmax(0,1fr)_minmax(18rem,1.15fr)] sm:items-end">
+        <div>
+          <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">
+            Request a source
+          </p>
+          <h2
+            id="source-request-title"
+            className="mt-1 text-xl font-black text-gray-950"
+          >
+            Want another website supported?
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-gray-600">
+            Share a link from the site. We use requests to decide which chapter
+            sources to add next.
+          </p>
+        </div>
+        <form onSubmit={handleSubmit} noValidate>
+          <label
+            htmlFor="requested-source-url"
+            className="text-sm font-bold text-gray-900"
+          >
+            Website or chapter URL
+          </label>
+          <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+            <input
+              id="requested-source-url"
+              type="url"
+              inputMode="url"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              value={sourceUrl}
+              onChange={(event) => {
+                setSourceUrl(event.target.value);
+                setError(null);
+                setStatus(null);
+              }}
+              placeholder="https://example.com/chapter/…"
+              aria-describedby="source-request-message"
+              aria-invalid={Boolean(error)}
+              className="min-w-0 flex-1 rounded-lg border-gray-300 bg-white text-gray-950 placeholder:text-gray-400 focus:border-emerald-600 focus:ring-emerald-600"
+            />
+            <button
+              type="submit"
+              className="rounded-lg bg-gray-950 px-5 py-2.5 text-sm font-bold text-white hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2"
+            >
+              Let us know
+            </button>
+          </div>
+          <p
+            id="source-request-message"
+            role={error ? "alert" : "status"}
+            className={`mt-2 min-h-5 text-sm font-medium ${
+              error ? "text-red-700" : "text-emerald-800"
+            }`}
+          >
+            {error ?? status}
+          </p>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/source-request.mjs
+++ b/src/lib/source-request.mjs
@@ -1,0 +1,18 @@
+import { normalizeChapterUrl } from "./chapter-url.mjs";
+
+export const SOURCE_REQUEST_EMAIL = "support@onepanel.app";
+
+export function createSourceRequestMailto(value) {
+  const normalizedUrl = normalizeChapterUrl(value);
+  if (!normalizedUrl) return null;
+
+  const subject = "OnePanel source request";
+  const body = [
+    "I'd like OnePanel Reader to support chapters from:",
+    normalizedUrl,
+    "",
+    "Anything else you should know:",
+  ].join("\n");
+
+  return `mailto:${SOURCE_REQUEST_EMAIL}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+}

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -18,7 +18,7 @@ const faqs = [
   {
     question: "Which chapter sources does OnePanel Reader support?",
     answer:
-      "You can upload one CBZ, CBR, ZIP, RAR, or PDF comic, select multiple JPG, JPEG, PNG, or WebP page images, or paste a chapter URL from opchapters.com. Multiple images are ordered by filename.",
+      "You can upload one CBZ, CBR, ZIP, RAR, or PDF comic, select multiple JPG, JPEG, PNG, or WebP page images, or paste a chapter URL from opchapters.com or tcbonepiecechapters.com. Multiple images are ordered by filename.",
   },
   {
     question: "What happens to uploaded files?",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,7 @@ import { useRouter } from "next/router";
 const audienceHighlights = [
   "Avoid accidental spoilers from full-page chapter scans.",
   "Read one clean panel at a time on phone, tablet, or desktop.",
-  "Jump from OP Chapters to a focused reader in seconds.",
+  "Jump from OP Chapters or TCB to a focused reader in seconds.",
 ];
 
 const launchProof = [
@@ -103,7 +103,7 @@ const Home: NextPage = () => {
                 </h1>
                 <p className="mt-5 max-w-2xl text-lg leading-8 text-gray-700">
                   OnePanel Reader is a spoiler-free manga reader: paste an OP
-                  Chapters link and it turns the chapter into a focused,
+                  Chapters or TCB link and it turns the chapter into a focused,
                   panel-by-panel reading flow so every reveal lands exactly when
                   it should. Use Standard for free, or upgrade to Pro for better
                   detection on complex page layouts.

--- a/src/pages/reader.tsx
+++ b/src/pages/reader.tsx
@@ -8,6 +8,7 @@ import ChapterComposer, {
 import ErrorMessage from "../components/ErrorMessage";
 import Footer from "../components/Footer";
 import Header from "../components/Header";
+import SourceRequestForm from "../components/SourceRequestForm";
 import UploadForm from "../components/UploadForm";
 import UpgradeModal from "../components/UpgradeModal";
 import { SignInButton, useAuth } from "../lib/auth";
@@ -254,9 +255,9 @@ const Reader: NextPage = () => {
                 Bring your own chapter.
               </h1>
               <p className="mx-auto mt-4 max-w-2xl text-lg leading-8 text-gray-700">
-                Import a comic from your library, your own page scans, or an OP
-                Chapters link. OnePanel turns it into a focused, panel-by-panel
-                reader.
+                Import a comic from your library, your own page scans, or a
+                supported chapter link. OnePanel turns it into a focused,
+                panel-by-panel reader.
               </p>
             </section>
 
@@ -293,17 +294,25 @@ const Reader: NextPage = () => {
                 </div>
                 <div className="flex flex-wrap items-baseline justify-between gap-2">
                   <p className="text-sm font-bold text-gray-950">
-                    Paste an OP Chapters link
+                    Paste a supported chapter link
                   </p>
-                  <p className="text-sm text-gray-600">
-                    No account needed ·{" "}
+                  <p className="flex flex-wrap gap-x-3 gap-y-1 text-sm text-gray-600">
+                    <span>No account needed</span>
                     <a
                       href="https://opchapters.com/"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="font-semibold text-emerald-700 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-900"
                     >
-                      Find a chapter on OP Chapters
+                      OP Chapters
+                    </a>
+                    <a
+                      href="https://tcbonepiecechapters.com/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-semibold text-emerald-700 underline decoration-emerald-300 underline-offset-4 hover:text-emerald-900"
+                    >
+                      TCB One Piece Chapters
                     </a>
                   </p>
                 </div>
@@ -331,8 +340,8 @@ const Reader: NextPage = () => {
                 <p className="font-bold">Private by design</p>
                 <p className="mt-1 leading-6 text-emerald-900/80">
                   File uploads are deleted after analysis. Only panel layout
-                  JSON remains, and you will need the original files again
-                  after this browser session.
+                  JSON remains, and you will need the original files again after
+                  this browser session.
                 </p>
               </aside>
               {isLoading && uploadProgress === null && (
@@ -357,6 +366,7 @@ const Reader: NextPage = () => {
                 </li>
               ))}
             </ul>
+            <SourceRequestForm />
           </div>
         </main>
         <Footer />

--- a/src/pages/spoiler-free-manga-reader.tsx
+++ b/src/pages/spoiler-free-manga-reader.tsx
@@ -23,7 +23,7 @@ const spoilerCauses = [
 const steps = [
   {
     title: "Bring your own chapter",
-    body: "Upload a CBZ, CBR, ZIP, RAR, or PDF comic, select multiple page images, or paste an OP Chapters link.",
+    body: "Upload a CBZ, CBR, ZIP, RAR, or PDF comic, select multiple page images, or paste an OP Chapters or TCB link.",
   },
   {
     title: "OnePanel builds a panel-by-panel flow",
@@ -67,7 +67,7 @@ const SpoilerFreeMangaReader: NextPage = () => (
       <title>Spoiler-Free Manga Reader | OnePanel Reader</title>
       <meta
         name="description"
-        content="Turn your comic files, page images, or OP Chapters links into a spoiler-free panel-by-panel manga reader. Standard detection is free."
+        content="Turn your comic files, page images, or OP Chapters and TCB links into a spoiler-free panel-by-panel manga reader. Standard detection is free."
       />
       <meta
         property="og:title"
@@ -101,9 +101,10 @@ const SpoilerFreeMangaReader: NextPage = () => (
               A spoiler-free manga reader for your own chapters
             </h1>
             <p className="mt-5 text-lg leading-8 text-gray-700">
-              OnePanel Reader turns comic files, page images, and OP Chapters
-              links into a panel-by-panel reading flow, so every reveal lands
-              exactly when you get to it. Standard panel detection is free.
+              OnePanel Reader turns comic files, page images, and OP Chapters or
+              TCB links into a panel-by-panel reading flow, so every reveal
+              lands exactly when you get to it. Standard panel detection is
+              free.
             </p>
             <ReaderCta />
           </div>
@@ -182,6 +183,15 @@ const SpoilerFreeMangaReader: NextPage = () => (
                 className="font-semibold text-gray-950 underline underline-offset-4 hover:text-gray-700"
               >
                 OP Chapters
+              </a>{" "}
+              or{" "}
+              <a
+                href="https://tcbonepiecechapters.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-gray-950 underline underline-offset-4 hover:text-gray-700"
+              >
+                TCB One Piece Chapters
               </a>
               . Uploaded files require an account and are deleted after
               analysis; only the panel layout remains for the current browser

--- a/test/chapter-url.test.mjs
+++ b/test/chapter-url.test.mjs
@@ -11,6 +11,12 @@ test("accepts HTTP and HTTPS chapter URLs from any source", () => {
     normalizeChapterUrl("http://reader.example/chapter/12"),
     "http://reader.example/chapter/12",
   );
+  assert.equal(
+    normalizeChapterUrl(
+      "https://tcbonepiecechapters.com/mangas/5/one-piece-chapter-1122/",
+    ),
+    "https://tcbonepiecechapters.com/mangas/5/one-piece-chapter-1122/",
+  );
 });
 
 test("adds HTTPS to bare domains and protocol-relative links", () => {

--- a/test/source-request.test.mjs
+++ b/test/source-request.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createSourceRequestMailto,
+  SOURCE_REQUEST_EMAIL,
+} from "../src/lib/source-request.mjs";
+
+test("creates a pre-addressed source request from a valid URL", () => {
+  const mailto = createSourceRequestMailto("example.com/manga/chapter-1");
+
+  assert.ok(mailto?.startsWith(`mailto:${SOURCE_REQUEST_EMAIL}?`));
+  assert.match(mailto, /OnePanel%20source%20request/);
+  assert.match(mailto, /https%3A%2F%2Fexample.com%2Fmanga%2Fchapter-1/);
+});
+
+test("rejects invalid and unsafe source request URLs", () => {
+  assert.equal(createSourceRequestMailto("not a url"), null);
+  assert.equal(createSourceRequestMailto("javascript:alert(1)"), null);
+});


### PR DESCRIPTION
## What changed

- Advertise and link TCB One Piece Chapters throughout the reader and marketing pages.
- Accept and forward TCB chapter URLs through the existing safe URL normalization flow.
- Add a validated source-request form that opens a pre-addressed support email draft.
- Add coverage for TCB URL normalization and source-request mailto construction.

## Why

Readers need to import chapters from TCB in addition to OP Chapters, and need a clear way to request other sources.

## Validation

- `npm run test` (32 tests passed)
- `npm run lint`
- `npm run build`
- Desktop and mobile browser QA

`npm audit` reports two existing high-severity `sharp` advisories; the suggested remediation upgrades to Next.js 16 and is outside this PR.