### PR TITLE
Add recurring source compatibility monitor

### DIFF
--- a/.github/workflows/source-monitor.yml
+++ b/.github/workflows/source-monitor.yml
@@ -1,0 +1,47 @@
+name: Source compatibility monitor
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: source-compatibility-monitor
+  cancel-in-progress: false
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Check configured chapter sources
+        id: monitor
+        env:
+          MONITOR_API_URL: ${{ secrets.MONITOR_API_URL }}
+          MONITOR_CHAPTER_URLS: ${{ secrets.MONITOR_CHAPTER_URLS }}
+        run: npm run monitor:sources 2>&1 | tee source-monitor.log
+      - name: Notify Telegram on failure
+        if: ${{ failure() && steps.monitor.outcome == 'failure' }}
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          tail -c 2500 source-monitor.log > telegram-error.txt
+          {
+            printf 'OnePanel source monitor failed.\n\n'
+            cat telegram-error.txt
+            printf '\n\n%s/actions/runs/%s' "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" "$GITHUB_RUN_ID"
+          } > telegram-message.txt
+          curl --fail-with-body --silent --show-error \
+            --request POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode text@telegram-message.txt

--- a/README.md
+++ b/README.md
@@ -143,3 +143,24 @@ and mode-specific access errors are available when the UI launches.
 The project currently uses the Pages Router on Next.js 15 and targets Node.js
 24 LTS. Run `npm audit` when updating dependencies and commit
 `package-lock.json` with dependency changes.
+
+### Source compatibility monitor
+
+The `Source compatibility monitor` GitHub Actions workflow runs daily and can
+also be started manually. It creates a Standard chapter through the deployed
+API, validates the returned chapter, and checks that every page is a reachable
+JPEG, PNG, GIF, WebP, or AVIF image whose declared content type matches its
+bytes.
+
+Configure these GitHub Actions repository secrets:
+
+- `MONITOR_API_URL`: the deployed API origin, without `/v2/chapter`
+- `MONITOR_CHAPTER_URLS`: a JSON array containing one stable, public chapter
+  URL per supported source, for example `["https://source.example/chapter-1"]`
+- `TELEGRAM_BOT_TOKEN`: token created with Telegram's BotFather
+- `TELEGRAM_CHAT_ID`: the destination user, group, or channel chat ID
+
+Add only chapters you are allowed to fetch, prefer small stable fixtures, and
+avoid URLs containing credentials because GitHub Actions logs show source host
+names. Run the same check locally with `npm run monitor:sources` after exporting
+`MONITOR_API_URL` and `MONITOR_CHAPTER_URLS`.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "eslint src --max-warnings=0",
+    "monitor:sources": "node scripts/monitor-sources.mjs",
     "start": "next start",
     "test": "node --test"
   },

--- a/scripts/monitor-sources.mjs
+++ b/scripts/monitor-sources.mjs
@@ -1,0 +1,24 @@
+import { monitorSource, parseSourceUrls } from "./source-monitor.mjs";
+
+const apiOrigin = process.env.MONITOR_API_URL?.replace(/\/$/, "");
+if (!apiOrigin) throw new Error("MONITOR_API_URL is required.");
+
+const sources = parseSourceUrls(process.env.MONITOR_CHAPTER_URLS ?? "");
+let failures = 0;
+
+for (const [index, source] of sources.entries()) {
+  const label = `Source ${index + 1} (${new URL(source).hostname})`;
+  try {
+    const result = await monitorSource(apiOrigin, source);
+    console.log(`PASS ${label}: ${result.pages} pages (${result.hash})`);
+  } catch (error) {
+    failures += 1;
+    console.error(
+      `FAIL ${label}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+if (failures > 0) {
+  throw new Error(`${failures} of ${sources.length} source checks failed.`);
+}

--- a/scripts/source-monitor.mjs
+++ b/scripts/source-monitor.mjs
@@ -1,0 +1,172 @@
+const SUPPORTED_IMAGE_TYPES = new Set([
+  "image/avif",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+
+export function parseSourceUrls(value) {
+  let parsed;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("MONITOR_CHAPTER_URLS must be a JSON array of URLs.");
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error("MONITOR_CHAPTER_URLS must contain at least one URL.");
+  }
+
+  return parsed.map((value, index) => {
+    let url;
+    try {
+      url = new URL(value);
+    } catch {
+      throw new Error(`Source ${index + 1} is not a valid URL.`);
+    }
+    if (!["http:", "https:"].includes(url.protocol)) {
+      throw new Error(`Source ${index + 1} must use HTTP or HTTPS.`);
+    }
+    return url.toString();
+  });
+}
+
+export function detectImageType(bytes) {
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  )
+    return "image/jpeg";
+  if (
+    bytes.length >= 8 &&
+    bytes
+      .subarray(0, 8)
+      .equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+  )
+    return "image/png";
+  if (
+    bytes.length >= 6 &&
+    ["GIF87a", "GIF89a"].includes(bytes.subarray(0, 6).toString("ascii"))
+  )
+    return "image/gif";
+  if (
+    bytes.length >= 12 &&
+    bytes.subarray(0, 4).toString("ascii") === "RIFF" &&
+    bytes.subarray(8, 12).toString("ascii") === "WEBP"
+  )
+    return "image/webp";
+  if (
+    bytes.length >= 12 &&
+    bytes.subarray(4, 8).toString("ascii") === "ftyp" &&
+    ["avif", "avis"].includes(bytes.subarray(8, 12).toString("ascii"))
+  )
+    return "image/avif";
+  return null;
+}
+
+export function validateChapter(value) {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    !Array.isArray(value.pages) ||
+    value.pages.length === 0
+  ) {
+    throw new Error("Chapter response has no pages.");
+  }
+
+  return value.pages.map((page, index) => {
+    if (
+      !page ||
+      typeof page !== "object" ||
+      typeof page.image !== "string" ||
+      page.image.length === 0
+    ) {
+      throw new Error(`Page ${index + 1} has no image URL.`);
+    }
+    if (
+      !Array.isArray(page.panels) ||
+      page.panels.length === 0 ||
+      page.panels.some(
+        (panel) =>
+          !panel || typeof panel.path !== "string" || panel.path.length === 0,
+      )
+    ) {
+      throw new Error(`Page ${index + 1} has invalid panels.`);
+    }
+    return page.image;
+  });
+}
+
+export async function fetchJson(url, init, timeoutMs = 120_000) {
+  const response = await fetch(url, {
+    ...init,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok)
+    throw new Error(
+      `${init?.method ?? "GET"} ${url} returned ${response.status}.`,
+    );
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("application/json"))
+    throw new Error(`${url} did not return JSON.`);
+  return response.json();
+}
+
+export async function verifyImage(imageUrl, pageNumber, timeoutMs = 30_000) {
+  const response = await fetch(imageUrl, {
+    headers: { Range: "bytes=0-31" },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok)
+    throw new Error(`Page ${pageNumber} image returned ${response.status}.`);
+
+  const reader = response.body?.getReader();
+  if (!reader)
+    throw new Error(`Page ${pageNumber} image had no response body.`);
+  const { value } = await reader.read();
+  await reader.cancel();
+  const detectedType = detectImageType(Buffer.from(value ?? []));
+  const declaredType = (response.headers.get("content-type") ?? "")
+    .split(";", 1)[0]
+    .toLowerCase();
+  if (!detectedType)
+    throw new Error(`Page ${pageNumber} is not a supported image format.`);
+  if (!SUPPORTED_IMAGE_TYPES.has(declaredType))
+    throw new Error(
+      `Page ${pageNumber} declared unexpected content type ${declaredType || "(missing)"}.`,
+    );
+  if (declaredType !== detectedType)
+    throw new Error(
+      `Page ${pageNumber} declared ${declaredType} but contains ${detectedType}.`,
+    );
+}
+
+export async function monitorSource(apiOrigin, sourceUrl) {
+  const created = await fetchJson(`${apiOrigin}/v2/chapter`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chapter_url: sourceUrl,
+      segmentation_mode: "standard",
+    }),
+  });
+  if (
+    !created ||
+    typeof created.chapter_hash !== "string" ||
+    created.chapter_hash.length === 0
+  ) {
+    throw new Error("Chapter creation returned no chapter_hash.");
+  }
+
+  const chapter = await fetchJson(
+    `${apiOrigin}/v2/chapter/${encodeURIComponent(created.chapter_hash)}`,
+  );
+  const images = validateChapter(chapter);
+  await Promise.all(
+    images.map((image, index) => verifyImage(image, index + 1)),
+  );
+  return { hash: created.chapter_hash, pages: images.length };
+}

--- a/test/source-monitor.test.mjs
+++ b/test/source-monitor.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  detectImageType,
+  parseSourceUrls,
+  validateChapter,
+} from "../scripts/source-monitor.mjs";
+
+test("parses a non-empty JSON list of HTTP sources", () => {
+  assert.deepEqual(parseSourceUrls('["https://example.com/chapter"]'), [
+    "https://example.com/chapter",
+  ]);
+  assert.throws(() => parseSourceUrls("[]"), /at least one/);
+  assert.throws(() => parseSourceUrls('["file:///tmp/page"]'), /HTTP or HTTPS/);
+});
+
+test("recognizes the image formats supported by the monitor", () => {
+  assert.equal(detectImageType(Buffer.from([0xff, 0xd8, 0xff])), "image/jpeg");
+  assert.equal(
+    detectImageType(Buffer.from("89504e470d0a1a0a", "hex")),
+    "image/png",
+  );
+  assert.equal(detectImageType(Buffer.from("GIF89a")), "image/gif");
+  assert.equal(
+    detectImageType(Buffer.from("524946460000000057454250", "hex")),
+    "image/webp",
+  );
+  assert.equal(
+    detectImageType(Buffer.from("000000006674797061766966", "hex")),
+    "image/avif",
+  );
+  assert.equal(detectImageType(Buffer.from("not an image")), null);
+});
+
+test("validates page images and panel paths", () => {
+  assert.deepEqual(
+    validateChapter({
+      pages: [
+        { image: "https://example.com/1.jpg", panels: [{ path: "M0 0" }] },
+      ],
+    }),
+    ["https://example.com/1.jpg"],
+  );
+  assert.throws(() => validateChapter({ pages: [] }), /no pages/);
+  assert.throws(
+    () => validateChapter({ pages: [{ image: "x", panels: [] }] }),
+    /invalid panels/,
+  );
+});


### PR DESCRIPTION
## Summary
- Add a daily and manually triggered GitHub Actions workflow for monitoring configured chapter sources.
- Validate chapter responses, panel paths, image formats, and declared content types.
- Add Telegram failure notifications, local execution documentation, and focused tests.

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm audit`