### PR TITLE
Trace Telegram upload results

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -278,9 +278,10 @@ export function createUploadedChapter(
 }
 
 export async function notifyChapterUpload(
-  fileCount: number,
+  files: File[],
   mode: SegmentationMode,
   token: string,
+  chapterHash: string,
 ): Promise<void> {
   try {
     await fetch("/api/chapter-upload-notification", {
@@ -289,7 +290,15 @@ export async function notifyChapterUpload(
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ fileCount, mode }),
+      body: JSON.stringify({
+        fileCount: files.length,
+        fileNames: files.map((file) => file.name),
+        mode,
+        chapterUrl: new URL(
+          `/chapter/${encodeURIComponent(chapterHash)}`,
+          window.location.origin,
+        ).href,
+      }),
     });
   } catch {
     // Notifications are operational telemetry and must not break the reader.

--- a/src/lib/telegram-notification.mjs
+++ b/src/lib/telegram-notification.mjs
@@ -1,5 +1,24 @@
 const TELEGRAM_API_ORIGIN = "https://api.telegram.org";
 const TELEGRAM_TIMEOUT_MS = 5_000;
+const MAX_FILENAMES_IN_NOTIFICATION = 10;
+const MAX_FILENAME_LENGTH = 120;
+
+function describeUploadedFiles(fileNames = []) {
+  const visibleNames = fileNames
+    .slice(0, MAX_FILENAMES_IN_NOTIFICATION)
+    .map((fileName) =>
+      fileName.length > MAX_FILENAME_LENGTH
+        ? `${fileName.slice(0, MAX_FILENAME_LENGTH - 1)}…`
+        : fileName,
+    );
+  if (visibleNames.length === 0) return [];
+
+  const remaining = fileNames.length - visibleNames.length;
+  return [
+    `File${fileNames.length === 1 ? "" : " names"}: ${visibleNames.join(", ")}`,
+    ...(remaining > 0 ? [`…and ${remaining} more`] : []),
+  ];
+}
 
 export function formatChapterNotification(event) {
   if (event.kind === "url") {
@@ -11,9 +30,11 @@ export function formatChapterNotification(event) {
   }
 
   return [
-    "OnePanel chapter uploaded.",
+    "OnePanel chapter uploaded successfully.",
     `Mode: ${event.mode}`,
     `Files: ${event.fileCount}`,
+    ...describeUploadedFiles(event.fileNames),
+    ...(event.chapterUrl ? [`Reader: ${event.chapterUrl}`] : []),
   ].join("\n");
 }
 

--- a/src/pages/api/chapter-upload-notification.ts
+++ b/src/pages/api/chapter-upload-notification.ts
@@ -7,7 +7,11 @@ import { segmentationModeSchema } from "../../lib/segmentation-modes.mjs";
 
 const requestSchema = z.object({
   fileCount: z.number().int().positive().max(1_000),
+  fileNames: z.array(z.string().min(1).max(1_024)).min(1).max(1_000),
+  chapterUrl: z.string().url().max(2_048),
   mode: segmentationModeSchema,
+}).refine((data) => data.fileNames.length === data.fileCount, {
+  message: "The file count must match the supplied file names.",
 });
 
 export default async function handler(
@@ -45,6 +49,8 @@ export default async function handler(
       kind: "upload",
       mode: body.data.mode,
       fileCount: body.data.fileCount,
+      fileNames: body.data.fileNames,
+      chapterUrl: body.data.chapterUrl,
     }),
   );
   res.status(204).end();

--- a/src/pages/reader.tsx
+++ b/src/pages/reader.tsx
@@ -216,7 +216,7 @@ const Reader: NextPage = () => {
         mode: "standard",
         source: "reader_page",
       });
-      await notifyChapterUpload(files.length, "standard", token);
+      await notifyChapterUpload(files, "standard", token, chapterHash);
       await router.push(`/chapter/${chapterHash}`);
     } catch (error) {
       if (controller.signal.aborted) return;

--- a/test/telegram-notification.test.mjs
+++ b/test/telegram-notification.test.mjs
@@ -16,14 +16,30 @@ test("formats URL submissions with their mode and URL", () => {
   );
 });
 
-test("formats uploads without exposing filenames", () => {
+test("formats successful uploads with filenames and the returned reader URL", () => {
   assert.equal(
     formatChapterNotification({
       kind: "upload",
       mode: "standard",
-      fileCount: 3,
+      fileCount: 1,
+      fileNames: ["one-piece-chapter-1123.cbz"],
+      chapterUrl: "https://www.onepanel.app/chapter/uploaded-chapter-hash",
     }),
-    "OnePanel chapter uploaded.\nMode: standard\nFiles: 3",
+    "OnePanel chapter uploaded successfully.\nMode: standard\nFiles: 1\nFile: one-piece-chapter-1123.cbz\nReader: https://www.onepanel.app/chapter/uploaded-chapter-hash",
+  );
+});
+
+test("limits the filenames shown in upload notifications", () => {
+  const fileNames = Array.from({ length: 12 }, (_, index) => `page-${index + 1}.png`);
+
+  assert.match(
+    formatChapterNotification({
+      kind: "upload",
+      mode: "standard",
+      fileCount: fileNames.length,
+      fileNames,
+    }),
+    /File names: page-1\.png, page-2\.png, page-3\.png, page-4\.png, page-5\.png, page-6\.png, page-7\.png, page-8\.png, page-9\.png, page-10\.png\n…and 2 more/,
   );
 });
 


### PR DESCRIPTION
## Summary

- Include uploaded filenames and the reader URL in Telegram chapter notifications.
- Validate upload metadata and matching file counts at the notification API boundary.
- Limit displayed filenames and cover successful upload formatting with tests.

## Testing

- Updated `test/telegram-notification.test.mjs` for reader URLs and filename limits.