### PR TITLE
Include reader links in chapter notifications

### DIFF
--- a/src/lib/chapter-notification.mjs
+++ b/src/lib/chapter-notification.mjs
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+const chapterCreatedSchema = z.object({
+  chapter_hash: z.string().min(1),
+});
+
+export function createUrlChapterNotification(
+  responseBody,
+  { mode, sourceUrl, readerOrigin },
+) {
+  const chapter = chapterCreatedSchema.safeParse(responseBody);
+  if (!chapter.success) return null;
+
+  try {
+    return {
+      kind: "url",
+      mode,
+      sourceUrl,
+      chapterUrl: new URL(
+        `/chapter/${encodeURIComponent(chapter.data.chapter_hash)}`,
+        readerOrigin,
+      ).href,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/telegram-notification.mjs
+++ b/src/lib/telegram-notification.mjs
@@ -25,7 +25,8 @@ export function formatChapterNotification(event) {
     return [
       "OnePanel chapter URL submitted.",
       `Mode: ${event.mode}`,
-      `URL: ${event.chapterUrl}`,
+      `URL: ${event.sourceUrl}`,
+      ...(event.chapterUrl ? [`Reader: ${event.chapterUrl}`] : []),
     ].join("\n");
   }
 

--- a/src/pages/api/onepanel/v2/chapter.ts
+++ b/src/pages/api/onepanel/v2/chapter.ts
@@ -1,6 +1,7 @@
 import { waitUntil } from "@vercel/functions";
 import { type NextApiRequest, type NextApiResponse } from "next";
 import { z } from "zod";
+import { createUrlChapterNotification } from "../../../../lib/chapter-notification.mjs";
 import { sendChapterNotification } from "../../../../lib/telegram-notification.mjs";
 import { segmentationModeSchema } from "../../../../lib/segmentation-modes.mjs";
 
@@ -8,6 +9,26 @@ const requestSchema = z.object({
   chapter_url: z.string().url(),
   segmentation_mode: segmentationModeSchema,
 });
+
+function firstHeaderValue(value: string | string[] | undefined) {
+  const firstValue = Array.isArray(value) ? value[0] : value;
+  return firstValue?.split(",", 1)[0]?.trim();
+}
+
+function getPublicOrigin(req: NextApiRequest) {
+  const protocol =
+    firstHeaderValue(req.headers["x-forwarded-proto"]) ?? "https";
+  const host = firstHeaderValue(
+    req.headers["x-forwarded-host"] ?? req.headers.host,
+  );
+  if (!host || (protocol !== "http" && protocol !== "https")) return null;
+
+  try {
+    return new URL(`${protocol}://${host}`).origin;
+  } catch {
+    return null;
+  }
+}
 
 export default async function handler(
   req: NextApiRequest,
@@ -45,13 +66,23 @@ export default async function handler(
     const responseBody = Buffer.from(await response.arrayBuffer());
     const contentType = response.headers.get("content-type");
     if (response.ok) {
-      waitUntil(
-        sendChapterNotification({
-          kind: "url",
-          mode: body.data.segmentation_mode,
-          chapterUrl: body.data.chapter_url,
-        }),
-      );
+      let responseData: unknown;
+      try {
+        responseData = JSON.parse(responseBody.toString("utf8"));
+      } catch {
+        responseData = null;
+      }
+      const publicOrigin = getPublicOrigin(req);
+      const notification = publicOrigin
+        ? createUrlChapterNotification(responseData, {
+            mode: body.data.segmentation_mode,
+            sourceUrl: body.data.chapter_url,
+            readerOrigin: publicOrigin,
+          })
+        : null;
+      if (notification) {
+        waitUntil(sendChapterNotification(notification));
+      }
     }
     if (contentType) res.setHeader("Content-Type", contentType);
     res.status(response.status).send(responseBody);

--- a/test/chapter-notification.test.mjs
+++ b/test/chapter-notification.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createUrlChapterNotification } from "../src/lib/chapter-notification.mjs";
+
+test("creates a URL submission notification with its reader link", () => {
+  assert.deepEqual(
+    createUrlChapterNotification(
+      { chapter_hash: "chapter/hash" },
+      {
+        mode: "standard",
+        sourceUrl: "https://example.com/chapter/12",
+        readerOrigin: "https://www.onepanel.app",
+      },
+    ),
+    {
+      kind: "url",
+      mode: "standard",
+      sourceUrl: "https://example.com/chapter/12",
+      chapterUrl: "https://www.onepanel.app/chapter/chapter%2Fhash",
+    },
+  );
+});
+
+test("does not create a notification from an invalid chapter response", () => {
+  assert.equal(
+    createUrlChapterNotification(
+      { chapter_hash: "" },
+      {
+        mode: "standard",
+        sourceUrl: "https://example.com/chapter/12",
+        readerOrigin: "https://www.onepanel.app",
+      },
+    ),
+    null,
+  );
+});

--- a/test/telegram-notification.test.mjs
+++ b/test/telegram-notification.test.mjs
@@ -5,14 +5,15 @@ import {
   sendChapterNotification,
 } from "../src/lib/telegram-notification.mjs";
 
-test("formats URL submissions with their mode and URL", () => {
+test("formats URL submissions with their source and reader URLs", () => {
   assert.equal(
     formatChapterNotification({
       kind: "url",
       mode: "standard",
-      chapterUrl: "https://example.com/chapter/12",
+      sourceUrl: "https://example.com/chapter/12",
+      chapterUrl: "https://www.onepanel.app/chapter/chapter-hash",
     }),
-    "OnePanel chapter URL submitted.\nMode: standard\nURL: https://example.com/chapter/12",
+    "OnePanel chapter URL submitted.\nMode: standard\nURL: https://example.com/chapter/12\nReader: https://www.onepanel.app/chapter/chapter-hash",
   );
 });
 
@@ -30,7 +31,10 @@ test("formats successful uploads with filenames and the returned reader URL", ()
 });
 
 test("limits the filenames shown in upload notifications", () => {
-  const fileNames = Array.from({ length: 12 }, (_, index) => `page-${index + 1}.png`);
+  const fileNames = Array.from(
+    { length: 12 },
+    (_, index) => `page-${index + 1}.png`,
+  );
 
   assert.match(
     formatChapterNotification({
@@ -49,7 +53,8 @@ test("logs Telegram API rejections without exposing credentials", async () => {
     {
       kind: "url",
       mode: "standard",
-      chapterUrl: "https://example.com/chapter/12",
+      sourceUrl: "https://example.com/chapter/12",
+      chapterUrl: "https://www.onepanel.app/chapter/chapter-hash",
     },
     {
       token: "secret-bot-token",
@@ -77,7 +82,10 @@ test("logs Telegram API rejections without exposing credentials", async () => {
       { status: 400, description: "Bad Request: chat not found" },
     ],
   ]);
-  assert.doesNotMatch(JSON.stringify(errors), /secret-bot-token|secret-chat-id/);
+  assert.doesNotMatch(
+    JSON.stringify(errors),
+    /secret-bot-token|secret-chat-id/,
+  );
 });
 
 test("logs a sanitized receipt for successful Telegram deliveries", async () => {
@@ -113,8 +121,16 @@ test("logs a sanitized receipt for successful Telegram deliveries", async () => 
   assert.deepEqual(messages, [
     [
       "Telegram chapter notification delivered.",
-      { status: 200, messageId: 42, chatType: "supergroup", chatIdSuffix: "7890" },
+      {
+        status: 200,
+        messageId: 42,
+        chatType: "supergroup",
+        chatIdSuffix: "7890",
+      },
     ],
   ]);
-  assert.doesNotMatch(JSON.stringify(messages), /secret-bot-token|1001234567890/);
+  assert.doesNotMatch(
+    JSON.stringify(messages),
+    /secret-bot-token|1001234567890/,
+  );
 });


### PR DESCRIPTION
## Summary

- Add reader URLs to successful chapter URL notifications.
- Derive reader links from the returned chapter hash and public request origin.
- Validate chapter responses and cover notification formatting with tests.

## Testing

- Added chapter notification tests for valid and invalid API responses.
- Updated Telegram notification tests for source and reader URLs.
- Full test, lint, build, and audit checks not run.