### PR TITLE
Include submitter emails in chapter notifications

### DIFF
--- a/src/lib/authenticated-chapter-notification.mjs
+++ b/src/lib/authenticated-chapter-notification.mjs
@@ -1,0 +1,61 @@
+import { createClerkClient, verifyToken } from "@clerk/backend";
+import { sendChapterNotification } from "./telegram-notification.mjs";
+
+function bearerToken(authorization) {
+  if (typeof authorization !== "string") return null;
+  return authorization.match(/^Bearer (.+)$/)?.[1] ?? null;
+}
+
+async function verifiedUserId(authorization) {
+  const token = bearerToken(authorization);
+  const secretKey = process.env.CLERK_SECRET_KEY;
+  if (!token || !secretKey) return null;
+
+  try {
+    const payload = await verifyToken(token, { secretKey });
+    return payload.sub;
+  } catch {
+    return null;
+  }
+}
+
+export async function getUserEmail(userId, options = {}) {
+  if (!userId) return null;
+
+  const getClerkClient =
+    options.getClerkClient ??
+    (() => createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY }));
+  const logger = options.logger ?? console;
+  try {
+    const client = await getClerkClient();
+    const user = await client.users.getUser(userId);
+    const email = user.primaryEmailAddress?.emailAddress;
+    return typeof email === "string" && email.length > 0 ? email : null;
+  } catch {
+    logger.error("Could not retrieve the chapter submitter's email.", {
+      userIdSuffix: userId.slice(-4),
+    });
+    return null;
+  }
+}
+
+export async function sendChapterNotificationForUser(
+  event,
+  userId,
+  options = {},
+) {
+  const userEmail = await getUserEmail(userId, options);
+  return sendChapterNotification(
+    userEmail ? { ...event, userEmail } : event,
+    options,
+  );
+}
+
+export async function sendChapterNotificationForAuthorization(
+  event,
+  authorization,
+  options = {},
+) {
+  const userId = await verifiedUserId(authorization);
+  return sendChapterNotificationForUser(event, userId, options);
+}

--- a/src/lib/telegram-notification.mjs
+++ b/src/lib/telegram-notification.mjs
@@ -25,6 +25,7 @@ export function formatChapterNotification(event) {
     return [
       "OnePanel chapter URL submitted.",
       `Mode: ${event.mode}`,
+      ...(event.userEmail ? [`Email: ${event.userEmail}`] : []),
       `URL: ${event.sourceUrl}`,
       ...(event.chapterUrl ? [`Reader: ${event.chapterUrl}`] : []),
     ].join("\n");
@@ -33,6 +34,7 @@ export function formatChapterNotification(event) {
   return [
     "OnePanel chapter uploaded successfully.",
     `Mode: ${event.mode}`,
+    ...(event.userEmail ? [`Email: ${event.userEmail}`] : []),
     `Files: ${event.fileCount}`,
     ...describeUploadedFiles(event.fileNames),
     ...(event.chapterUrl ? [`Reader: ${event.chapterUrl}`] : []),

--- a/src/pages/api/chapter-upload-notification.ts
+++ b/src/pages/api/chapter-upload-notification.ts
@@ -2,7 +2,7 @@ import { verifyToken } from "@clerk/nextjs/server";
 import { waitUntil } from "@vercel/functions";
 import { type NextApiRequest, type NextApiResponse } from "next";
 import { z } from "zod";
-import { sendChapterNotification } from "../../lib/telegram-notification.mjs";
+import { sendChapterNotificationForUser } from "../../lib/authenticated-chapter-notification.mjs";
 import { segmentationModeSchema } from "../../lib/segmentation-modes.mjs";
 
 const requestSchema = z.object({
@@ -31,8 +31,10 @@ export default async function handler(
     return;
   }
 
+  let userId: string;
   try {
-    await verifyToken(token, { secretKey });
+    const payload = await verifyToken(token, { secretKey });
+    userId = payload.sub;
   } catch {
     res.status(401).json({ detail: "Authentication required." });
     return;
@@ -45,13 +47,16 @@ export default async function handler(
   }
 
   waitUntil(
-    sendChapterNotification({
-      kind: "upload",
-      mode: body.data.mode,
-      fileCount: body.data.fileCount,
-      fileNames: body.data.fileNames,
-      chapterUrl: body.data.chapterUrl,
-    }),
+    sendChapterNotificationForUser(
+      {
+        kind: "upload",
+        mode: body.data.mode,
+        fileCount: body.data.fileCount,
+        fileNames: body.data.fileNames,
+        chapterUrl: body.data.chapterUrl,
+      },
+      userId,
+    ),
   );
   res.status(204).end();
 }

--- a/src/pages/api/onepanel/v2/chapter.ts
+++ b/src/pages/api/onepanel/v2/chapter.ts
@@ -1,8 +1,8 @@
 import { waitUntil } from "@vercel/functions";
 import { type NextApiRequest, type NextApiResponse } from "next";
 import { z } from "zod";
+import { sendChapterNotificationForAuthorization } from "../../../../lib/authenticated-chapter-notification.mjs";
 import { createUrlChapterNotification } from "../../../../lib/chapter-notification.mjs";
-import { sendChapterNotification } from "../../../../lib/telegram-notification.mjs";
 import { segmentationModeSchema } from "../../../../lib/segmentation-modes.mjs";
 
 const requestSchema = z.object({
@@ -81,7 +81,12 @@ export default async function handler(
           })
         : null;
       if (notification) {
-        waitUntil(sendChapterNotification(notification));
+        waitUntil(
+          sendChapterNotificationForAuthorization(
+            notification,
+            req.headers.authorization,
+          ),
+        );
       }
     }
     if (contentType) res.setHeader("Content-Type", contentType);

--- a/test/authenticated-chapter-notification.test.mjs
+++ b/test/authenticated-chapter-notification.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getUserEmail } from "../src/lib/authenticated-chapter-notification.mjs";
+
+test("gets the authenticated user's primary email from Clerk", async () => {
+  const requestedUserIds = [];
+
+  const email = await getUserEmail("user_1234", {
+    getClerkClient: async () => ({
+      users: {
+        getUser: async (userId) => {
+          requestedUserIds.push(userId);
+          return {
+            primaryEmailAddress: { emailAddress: "reader@example.com" },
+          };
+        },
+      },
+    }),
+  });
+
+  assert.equal(email, "reader@example.com");
+  assert.deepEqual(requestedUserIds, ["user_1234"]);
+});
+
+test("continues without an email when Clerk cannot load the user", async () => {
+  const errors = [];
+
+  const email = await getUserEmail("user_1234", {
+    getClerkClient: async () => ({
+      users: {
+        getUser: async () => {
+          throw new Error("Clerk unavailable");
+        },
+      },
+    }),
+    logger: { error: (...args) => errors.push(args) },
+  });
+
+  assert.equal(email, null);
+  assert.deepEqual(errors, [
+    [
+      "Could not retrieve the chapter submitter's email.",
+      { userIdSuffix: "1234" },
+    ],
+  ]);
+});

--- a/test/telegram-notification.test.mjs
+++ b/test/telegram-notification.test.mjs
@@ -10,10 +10,11 @@ test("formats URL submissions with their source and reader URLs", () => {
     formatChapterNotification({
       kind: "url",
       mode: "standard",
+      userEmail: "reader@example.com",
       sourceUrl: "https://example.com/chapter/12",
       chapterUrl: "https://www.onepanel.app/chapter/chapter-hash",
     }),
-    "OnePanel chapter URL submitted.\nMode: standard\nURL: https://example.com/chapter/12\nReader: https://www.onepanel.app/chapter/chapter-hash",
+    "OnePanel chapter URL submitted.\nMode: standard\nEmail: reader@example.com\nURL: https://example.com/chapter/12\nReader: https://www.onepanel.app/chapter/chapter-hash",
   );
 });
 
@@ -22,11 +23,12 @@ test("formats successful uploads with filenames and the returned reader URL", ()
     formatChapterNotification({
       kind: "upload",
       mode: "standard",
+      userEmail: "reader@example.com",
       fileCount: 1,
       fileNames: ["one-piece-chapter-1123.cbz"],
       chapterUrl: "https://www.onepanel.app/chapter/uploaded-chapter-hash",
     }),
-    "OnePanel chapter uploaded successfully.\nMode: standard\nFiles: 1\nFile: one-piece-chapter-1123.cbz\nReader: https://www.onepanel.app/chapter/uploaded-chapter-hash",
+    "OnePanel chapter uploaded successfully.\nMode: standard\nEmail: reader@example.com\nFiles: 1\nFile: one-piece-chapter-1123.cbz\nReader: https://www.onepanel.app/chapter/uploaded-chapter-hash",
   );
 });
 


### PR DESCRIPTION
## Summary

- Retrieve authenticated submitter emails from Clerk.
- Include submitter emails in Telegram notifications for uploads and chapter links.
- Add coverage for email lookup failures and notification formatting.

## Testing

- Not run